### PR TITLE
Remove EOFError capture so that EOF can end exit the program

### DIFF
--- a/npcsh/shell.py
+++ b/npcsh/shell.py
@@ -177,7 +177,7 @@ Welcome to \033[1;94mnpc\033[0m\033[1;38;5;202msh\033[0m!
          \033[1;94m|_|
 
 Begin by asking a question, issuing a bash command, or typing '/help' for more information.
-"""
+        """
     )
 
     current_npc = None

--- a/npcsh/shell_helpers.py
+++ b/npcsh/shell_helpers.py
@@ -569,17 +569,14 @@ def get_multiline_input(prompt: str) -> str:
     lines = []
     current_prompt = prompt
     while True:
-        try:
-            line = input(current_prompt)
-            if line.endswith("\\"):
-                lines.append(line[:-1])  # Remove the backslash
-                # Use a continuation prompt for the next line
-                current_prompt = readline_safe_prompt("> ")
-            else:
-                lines.append(line)
-                break
-        except EOFError:
-            break  # Handle EOF (Ctrl+D)
+        line = input(current_prompt)
+        if line.endswith("\\"):
+            lines.append(line[:-1])  # Remove the backslash
+            # Use a continuation prompt for the next line
+            current_prompt = readline_safe_prompt("> ")
+        else:
+            lines.append(line)
+            break
     return "\n".join(lines)
 
 


### PR DESCRIPTION
* Fixes #99
* tested with multiple CRs to ensure that the shell exits only when EOF is used.
* tested to ensure that EOF (Ctrl d) after entering text does not exit.
* Also change some spacing for multline string that seem to cause:
```
    shell.py:168: SyntaxWarning: invalid escape sequence '\ '
      """
```