### PR TITLE
bump pillow to 12.1.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,7 +27,7 @@ opencv-python
 openai
 openai-whisper
 pandas
-Pillow
+Pillow==12.1.1
 playsound==1.2.2
 psycopg2-binary
 pyaudio

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ base_requirements = [
     "rich",
     "colorama",
     "docstring_parser",
-    "Pillow",
+    "Pillow>=12.1.1",
     "python-dotenv",
     "pandas",
     "polars",


### PR DESCRIPTION
These packages have security fixes available:

- `pillow` 11.3.0 -> 12.1.1 (CVE-2026-25990)

Bumped each one to the minimum safe version.