### PR TITLE
bump pygments to 2.20.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -32,7 +32,7 @@ playsound==1.2.2
 psycopg2-binary
 pyaudio
 pyautogui
-pygments
+pygments==2.20.0
 PyMuPDF
 pyttsx3
 python-dotenv

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ base_requirements = [
     "PyMuPDF",
     "pyautogui",
     "pydantic", 
-    "pygments",
+    "pygments>=2.20.0",
     "sqlalchemy",
     "termcolor",
     "rich",


### PR DESCRIPTION
These packages have security fixes available:

- `pygments` 2.19.2 -> 2.20.0 (CVE-2026-4539)

Bumped each one to the minimum safe version.