### PR TITLE
Security fixes, NPCArray jinx support, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,20 @@ print(coder.run("Write a script that finds duplicate files by hash in the curren
 
 ```python
 from npcpy import get_llm_response
+from npcpy.streaming import parse_stream_chunk
 
 response = get_llm_response("Explain quantum entanglement.", model='qwen3.5:2b', provider='ollama', stream=True)
 for chunk in response['response']:
-    print(chunk.get('message', {}).get('content', ''), end='', flush=True)
+    content, _, _ = parse_stream_chunk(chunk, provider='ollama')
+    if content:
+        print(content, end='', flush=True)
+
+# Works the same with any provider
+response = get_llm_response("Explain quantum entanglement.", model='gemini-2.5-flash', provider='gemini', stream=True)
+for chunk in response['response']:
+    content, _, _ = parse_stream_chunk(chunk, provider='gemini')
+    if content:
+        print(content, end='', flush=True)
 ```
 
 ### JSON output
@@ -115,7 +125,8 @@ result = response['response']
 print(result['tone'], result['key_phrases'])
 ```
 
-### Pydantic structured output
+<details>
+<summary><b>Pydantic structured output</b></summary>
 
 Pass a Pydantic model and the JSON schema is sent to the LLM directly.
 
@@ -141,7 +152,10 @@ for p in response['response']['planets']:
     print(f"{p['name']}: {p['distance_au']} AU, {p['num_moons']} moons")
 ```
 
-### Image, audio, and video generation
+</details>
+
+<details>
+<summary><b>Image, audio, and video generation</b></summary>
 
 ```python
 from npcpy.llm_funcs import gen_image, gen_video
@@ -160,6 +174,8 @@ with open("hello.wav", "wb") as f:
 result = gen_video("A cat riding a skateboard", model='veo-3.1-fast-generate-preview', provider='gemini')
 print(result['output'])
 ```
+
+</details>
 
 ### Multi-agent team
 
@@ -185,7 +201,8 @@ result = team.orchestrate("What are the trends in renewable energy adoption?")
 print(result['output'])
 ```
 
-### Team from files
+<details>
+<summary><b>Team from files — .npc, .jinx, team.ctx</b></summary>
 
 **team.ctx:**
 ```yaml
@@ -276,7 +293,10 @@ my_project/
 ./npc_team/jinxes/lib/sh.jinx bash_command="echo hello"
 ```
 
-### MCP server integration
+</details>
+
+<details>
+<summary><b>MCP server integration</b></summary>
 
 Add MCP servers to your team for external tool access:
 
@@ -311,7 +331,10 @@ if __name__ == "__main__":
 
 The team's NPCs automatically get access to MCP tools alongside their jinxes.
 
-### Agent definitions in markdown
+</details>
+
+<details>
+<summary><b>Agent definitions in markdown &amp; Skills</b></summary>
 
 **agents.md** — multiple agents in one file:
 ```markdown
@@ -332,8 +355,6 @@ provider: gemini
 ---
 You translate content between languages while preserving tone and idiom.
 ```
-
-### Skills
 
 Skills are knowledge-content jinxes that provide instructional sections to agents on demand.
 
@@ -360,6 +381,8 @@ jinxes:
   - {{ Jinx('skills/code-review') }}
 ```
 
+</details>
+
 ### CLI tools
 
 ```bash
@@ -379,7 +402,40 @@ npc-opencode / npc-aider / npc-amp
 npc-plugin claude
 ```
 
-### Knowledge graphs
+### NPCArray — parallel jinx across multiple NPCs
+
+Run any jinx in parallel across a list of NPC instances and collect results as an array:
+
+```python
+from npcpy import NPC
+from npcpy.npc_array import NPCArray
+
+# Three NPCs with different models/providers
+npcs = [
+    NPC(name='drafter', primary_directive='Draft concise commit messages.', model='qwen3:4b', provider='ollama'),
+    NPC(name='reviewer', primary_directive='Review and improve commit messages for clarity.', model='gemini-2.5-flash', provider='gemini'),
+    NPC(name='enforcer', primary_directive='Check commit messages follow Conventional Commits spec.', model='gemini-2.5-flash', provider='gemini'),
+]
+
+arr = NPCArray.from_npcs(npcs)
+
+# Run the same jinx on all three in parallel, collect results
+results = arr.jinx('summarize', inputs={'topic': 'fix auth middleware to propagate clerkUserId through GraphQL resolvers'}).collect()
+for npc, result in zip(npcs, results.data):
+    print(f"[{npc.name}] {result}")
+```
+
+You can also pass a list directly to `jinx.execute()`:
+
+```python
+from npcpy.npc_compiler import load_jinx_from_file
+
+jinx = load_jinx_from_file('npc_team/jinxes/analyze.jinx')
+results = jinx.execute({'topic': 'rate limiting'}, npc=npcs)  # list → parallel NPCArray run
+```
+
+<details>
+<summary><b>Knowledge graphs</b></summary>
 
 Build, evolve, and search knowledge graphs from text. The KG grows through waking (assimilation), sleeping (consolidation), and dreaming (speculative synthesis).
 
@@ -410,15 +466,6 @@ kg, _ = kg_evolve_incremental(
     model="qwen3:4b", provider="ollama", get_concepts=True,
 )
 
-kg, _ = kg_evolve_incremental(
-    kg,
-    new_content_text=(
-        "PR #418: Fixed GraphQL resolver auth context — clerkUserId now propagated "
-        "through dataloader chain. Added integration tests for nested query auth."
-    ),
-    model="qwen3:4b", provider="ollama", get_concepts=True,
-)
-
 # Consolidate — merge redundant nodes, strengthen high-frequency edges
 kg, sleep_report = kg_sleep_process(kg, model="qwen3:4b", provider="ollama")
 
@@ -433,9 +480,7 @@ for r in results:
 print(f"{len(kg['facts'])} facts, {len(kg['concepts'])} concepts")
 ```
 
-### Memory extraction
-
-Extract structured memories from conversations with a self-improving quality loop.
+Extract structured memories from conversations:
 
 ```python
 from npcpy.llm_funcs import get_facts
@@ -446,10 +491,6 @@ User: We're ripping out Stripe entirely and moving auth to Clerk. The JWT verifi
 Assistant: Got it. I'll update the middleware chain. What about the existing session store?
 User: Kill the Redis session cache — Clerk handles session state on their end.
       Also, the CSP headers need clerk.accounts.dev and clerk.enpisi.com added to connect-src.
-Assistant: Makes sense. Should I keep the rate limiter on /api/auth endpoints?
-User: Switch it from the per-session token bucket to a per-IP sliding window.
-      The Stripe webhook endpoint at /api/stripe/webhook can be deleted entirely.
-Assistant: Will do. I'll also remove the STRIPE_SECRET_KEY from the env template.
 """
 
 facts = get_facts(conversation, model="qwen3:4b", provider="ollama")
@@ -458,11 +499,12 @@ for f in facts:
 # [architecture] Auth provider migrated from Stripe to Clerk with JWT verification via ClerkMiddleware
 # [infrastructure] Redis session cache removed — Clerk manages session state
 # [security] CSP connect-src updated to include clerk.accounts.dev and clerk.enpisi.com
-# [architecture] Rate limiter changed from per-session token bucket to per-IP sliding window
-# [cleanup] /api/stripe/webhook endpoint deleted; STRIPE_SECRET_KEY removed from env template
 ```
 
-### Sememolution (population-based KG evolution)
+</details>
+
+<details>
+<summary><b>Sememolution — population-based KG evolution</b></summary>
 
 Maintain a population of KG variants that evolve independently. Each individual has Poisson-sampled search parameters, producing different traversals each query. Selection pressure from response ranking drives convergence toward useful graph structures.
 
@@ -498,7 +540,10 @@ print(f"Generation {stats['generation']} | avg fitness {stats['avg_fitness']:.3f
       f"best fitness {stats['best_fitness']:.3f} | diversity {stats['diversity']:.3f}")
 ```
 
-### Fine-tuning (SFT, RL, MLX)
+</details>
+
+<details>
+<summary><b>Fine-tuning (SFT, RL, MLX)</b></summary>
 
 ```python
 from npcpy.ft.sft import run_sft
@@ -535,6 +580,8 @@ y_train = [
 
 model_path = run_sft(X_train=X_train, y_train=y_train)
 ```
+
+</details>
 
 ## Features
 

--- a/npcpy/ft/diff.py
+++ b/npcpy/ft/diff.py
@@ -16,6 +16,7 @@ except ImportError:
     TORCH_AVAILABLE = False
 
 import math
+import dataclasses
 from dataclasses import dataclass, field
 from typing import List, Optional
 import numpy as np
@@ -260,7 +261,7 @@ if TORCH_AVAILABLE:
             )
             torch.save({
                 'model_state_dict': self.model.state_dict(),
-                'config': self.config,
+                'config': dataclasses.asdict(self.config),
             }, final_path)
             
             return self.config.output_model_path
@@ -335,7 +336,7 @@ def train_diffusion(image_paths, captions=None, config=None,
     trainer = DiffusionTrainer(config)
 
     if resume_from and os.path.exists(resume_from):
-        checkpoint = torch.load(resume_from, map_location=trainer.device)
+        checkpoint = torch.load(resume_from, map_location=trainer.device, weights_only=True)
         trainer.model.load_state_dict(checkpoint['model_state_dict'])
         print(f'Resumed from {resume_from}')
 
@@ -355,10 +356,11 @@ def generate_image(model_path, prompt=None, num_samples=1, image_size=128):
     
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     
-    checkpoint = torch.load(model_path, map_location=device, weights_only=False)
-    
+    checkpoint = torch.load(model_path, map_location=device, weights_only=True)
+
     if 'config' in checkpoint:
-        config = checkpoint['config']
+        cfg = checkpoint['config']
+        config = DiffusionConfig(**cfg) if isinstance(cfg, dict) else cfg
     else:
         config = DiffusionConfig(image_size=image_size)
     

--- a/npcpy/gen/image_gen.py
+++ b/npcpy/gen/image_gen.py
@@ -33,9 +33,11 @@ def generate_image_diffusers(
             if os.path.exists(checkpoint_path):
                 print(f"🌋 Found model_final.pt at {checkpoint_path}.")
                 
-                checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
-                
-                if 'config' in checkpoint and hasattr(checkpoint['config'], 'image_size'):
+                checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=True)
+
+                cfg = checkpoint.get('config')
+                has_image_size = (isinstance(cfg, dict) and 'image_size' in cfg) or hasattr(cfg, 'image_size')
+                if 'config' in checkpoint and has_image_size:
                     print(f"🌋 Detected custom SimpleUNet model, using custom generation")
                     from npcpy.ft.diff import generate_image as custom_generate_image
                     

--- a/npcpy/gen/response.py
+++ b/npcpy/gen/response.py
@@ -1506,7 +1506,7 @@ def get_litellm_response(
             }
 
         if stream:
-            result["response"] = resp  
+            result["response"] = resp
             return result
         else:
             

--- a/npcpy/gen/world_gen.py
+++ b/npcpy/gen/world_gen.py
@@ -154,7 +154,8 @@ def _step_diamond(
     if not ckpt_path.exists():
         raise FileNotFoundError(f"Checkpoint not found: {model_path}")
 
-    ckpt = torch.load(ckpt_path, map_location=device)
+    # DIAMOND checkpoints contain OmegaConf/Hydra config objects; weights_only=True would fail.
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
 
     cfg = ckpt.get("config")
     if cfg is None:
@@ -462,7 +463,8 @@ def load_diamond_model(
     from omegaconf import OmegaConf
 
     ckpt_path = Path(model_path)
-    ckpt = torch.load(ckpt_path, map_location=device)
+    # DIAMOND checkpoints contain OmegaConf/Hydra config objects; weights_only=False required.
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
     cfg = ckpt.get("config")
 
     agent_cfg = OmegaConf.create(cfg["agent"]) if isinstance(cfg, dict) else cfg.agent

--- a/npcpy/mcp_server.py
+++ b/npcpy/mcp_server.py
@@ -140,8 +140,8 @@ class NPCServerState:
         # steps contain the engine's code which reads action/args from context.
         # Reconstruct those from _raw_steps and render templates with the MCP args.
         if hasattr(jinx, '_raw_steps') and jinx._raw_steps:
-            from jinja2 import Environment
-            env = Environment()
+            from jinja2.sandbox import SandboxedEnvironment
+            env = SandboxedEnvironment()
             for raw_step in jinx._raw_steps:
                 if raw_step.get('engine') and raw_step['engine'] not in ('python', 'bash'):
                     for k, v in raw_step.items():

--- a/npcpy/npc_compiler.py
+++ b/npcpy/npc_compiler.py
@@ -692,14 +692,20 @@ class Jinx:
                 messages: Optional[List[Dict[str, str]]] = None,
                 extra_globals: Optional[Dict[str, Any]] = None,
                 jinja_env: Optional[Environment] = None):
-        
+
         if jinja_env is None:
             jinja_env = SandboxedEnvironment(
                 loader=DictLoader({}),
                 undefined=SilentUndefined,
             )
-        
+
         active_npc = self.npc if self.npc else npc
+
+        # If npc is a list or NPCArray, run this jinx in parallel across all instances
+        from npcpy.npc_array import NPCArray
+        if isinstance(active_npc, (list, NPCArray)):
+            arr = NPCArray.from_npcs(active_npc) if isinstance(active_npc, list) else active_npc
+            return arr.jinx(self.jinx_name, inputs=input_values).collect()
         
         context = (
             active_npc.shared_context.copy() 
@@ -3687,9 +3693,11 @@ class Agent(NPC):
         agents_md: str = None,
         skills_dir: str = None,
         mcp_servers: list = None,
+        safe_tools: bool = False,
         **kwargs,
     ):
-        all_tools = list(_DEFAULT_AGENT_TOOLS)
+        _EXEC_TOOLS = {_tool_sh, _tool_python}
+        all_tools = [t for t in _DEFAULT_AGENT_TOOLS if not safe_tools or t not in _EXEC_TOOLS]
         if extra_tools:
             all_tools.extend(extra_tools)
         if tools is not None:

--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -2166,8 +2166,8 @@ def test_jinx():
     
     jinx = Jinx(jinx_data=jinx_data)
     
-    from jinja2 import Environment
-    temp_env = Environment()
+    from jinja2.sandbox import SandboxedEnvironment
+    temp_env = SandboxedEnvironment()
     jinx.render_first_pass(temp_env, {})
     
     conversation_id = f"jinx_test_{uuid.uuid4().hex[:8]}"

--- a/npcpy/work/desktop.py
+++ b/npcpy/work/desktop.py
@@ -15,6 +15,7 @@ try:
     import pyautogui
 except Exception:
     print('could not import pyautogui')
+import shlex
 import time
 import subprocess
 
@@ -38,7 +39,7 @@ def perform_action(action):
         elif action_type in ("shell", "bash"):
             command = action.get("command", "")
             print(f"Executing shell command: {command}")
-            subprocess.Popen(command, shell=True)
+            subprocess.Popen(shlex.split(command), shell=False)
             return {"status": "success", "output": f"Launched '{command}'."}
         
         elif action_type == "type":


### PR DESCRIPTION
## Summary

- **#216** `desktop.py`: `shell=True` → `shlex.split` + `shell=False`
- **#200** `diff.py`, `image_gen.py`: `weights_only=True`; save config as plain dict for safe round-trip. `world_gen.py`: explicit `weights_only=False` with comment (DIAMOND checkpoints require it)
- **#215/#217** `Agent` gains `safe_tools=True` param — excludes `_tool_sh`/`_tool_python` from default tool set
- **#197** `serve.py`, `mcp_server.py`: bare `Environment()` → `SandboxedEnvironment()` for user-controlled Jinja2 rendering
- **#196** `Jinx.execute()` accepts a list or `NPCArray` as `npc` — creates an `NPCArray` internally and runs the jinx in parallel across all instances
- **README**: streaming example updated to use `parse_stream_chunk` (provider-agnostic); new NPCArray jinx section; longer sections collapsed into dropdowns

## Issues closed

Closes #216, #200, #215, #217, #197, #196