### PR TITLE
fix: guard optional ollama import and default kg_initial zoom-in to True

### DIFF
--- a/npcpy/gen/response.py
+++ b/npcpy/gen/response.py
@@ -13,10 +13,28 @@ logger = logging.getLogger(__name__)
 
 try:
     import ollama
+    HAS_OLLAMA = True
 except ImportError:
-    pass
+    ollama = None
+    HAS_OLLAMA = False
 except OSError:
+    ollama = None
+    HAS_OLLAMA = False
     logger.warning("Ollama is not installed or not available.")
+
+
+def _require_ollama() -> None:
+    """Raise a clear ImportError when the optional ``ollama`` package is absent.
+
+    Called at each entry point into the ollama provider so that users get a
+    descriptive error instead of a bare ``NameError: name 'ollama' is not
+    defined`` at an arbitrary call site.
+    """
+    if not HAS_OLLAMA:
+        raise ImportError(
+            "The 'ollama' package is required for the ollama provider. "
+            "Install it with: pip install ollama"
+        )
 
 try:
     import litellm
@@ -362,6 +380,7 @@ def get_ollama_response(
     """
     Generates a response using the Ollama API, supporting both streaming and non-streaming.
     """
+    _require_ollama()
 
     options = {}
 

--- a/npcpy/memory/knowledge_graph.py
+++ b/npcpy/memory/knowledge_graph.py
@@ -204,7 +204,7 @@ def kg_initial(content,
                verbose=True,
                embedding_model=None,
                embedding_provider=None,
-               zoom_in_enabled=False):
+               zoom_in_enabled=True):
 
     if generation is None:
         CURRENT_GENERATION = 0


### PR DESCRIPTION
Fixes #212, fixes #214. Thanks @cagostino for the go-ahead on both in #214.

## #212 — `NameError` when `ollama` package is absent

The module-level `try: import ollama` silently passed on `ImportError`, so the six `ollama.chat` / `ollama.show` call sites later in `response.py` raised `NameError: name 'ollama' is not defined` at runtime. Users installing `npcpy` without the optional `ollama` dep hit a confusing crash instead of an actionable message.

**Fix** — replace the bare `pass` with an explicit `ollama = None` sentinel plus a `HAS_OLLAMA` flag, and gate `get_ollama_response` on a small `_require_ollama()` helper:

```python
def _require_ollama() -> None:
    if not HAS_OLLAMA:
        raise ImportError(
            "The 'ollama' package is required for the ollama provider. "
            "Install it with: pip install ollama"
        )
```

The other `ollama.show` call in `get_model_context_window` (line 225) is already inside a `try: ... except Exception: pass`, so it degrades cleanly to the default num_ctx — no extra guard needed there.

## #214 — `kg_initial` dropped implied facts by default

`kg_initial(..., zoom_in_enabled=False)` meant the `zoom_in` branch that generates implied facts never ran unless callers set the flag explicitly. That contradicted the existing `test_kg_initial_from_content` expectation:

```python
assert len(result['facts']) >= 2  # extracted + implied
```

Per the issue suggestion and the test's intent, flipped the default to `True` so implied-fact generation is the documented default behavior. Callers that want the old behavior can still pass `zoom_in_enabled=False` explicitly.

## Verification

- `tests/test_knowledge_graph.py` — **39 passed** (was 38 passed, 1 failed before).
- Before the fix:
  ```
  >>> get_ollama_response(prompt="hi", model="llama3:latest", messages=[...])
  NameError: name 'ollama' is not defined
  ```
- After the fix:
  ```
  >>> get_ollama_response(prompt="hi", model="llama3:latest", messages=[...])
  ImportError: The 'ollama' package is required for the ollama provider.
  Install it with: pip install ollama
  ```

Happy to iterate if either default (zoom-in-on / import-guard placement) isn't the shape you want.