### PR TITLE
v1.4.21: MLX music gen, OpenAI image unwrap, team-routed NPC lookup

### DIFF
--- a/npcpy/data/load.py
+++ b/npcpy/data/load.py
@@ -1,4 +1,4 @@
-import fitz
+import pypdf
 import pandas as pd
 import json
 import io
@@ -55,10 +55,10 @@ def load_image(file_path):
     return df
 
 def load_pdf(file_path):
-    pdf_document = fitz.open(file_path)
+    reader = pypdf.PdfReader(file_path)
     full_text = ""
-    for page in pdf_document:
-        full_text += page.get_text() + "\n"
+    for page in reader.pages:
+        full_text += (page.extract_text() or "") + "\n"
     return full_text
 
 def load_docx(file_path):

--- a/npcpy/gen/audio_gen.py
+++ b/npcpy/gen/audio_gen.py
@@ -809,34 +809,6 @@ def base64_to_audio(b64_string: str) -> bytes:
 
 # ─── Music generation ─────────────────────────────────────────────────
 
-def music_musicgen_mlx(
-    prompt: str,
-    duration: int = 10,
-    model: str = "facebook/musicgen-medium",
-) -> bytes:
-    """Generate music natively on Apple Silicon via MLX.
-
-    Uses Apple's mlx-examples MusicGen port (vendored into npcpy.gen.mlx_musicgen).
-    Runs on the Apple GPU via MLX — no CUDA/MPS/CPU fallback needed.
-    Returns WAV bytes at 32 kHz.
-    """
-    import numpy as np
-    import scipy.io.wavfile as wavfile
-    import mlx.core as mx
-    from npcpy.gen.mlx_musicgen.musicgen import MusicGen
-
-    mg = MusicGen.from_pretrained(model)
-    # MusicGen's MLX port uses ~50 tokens/sec; max_steps maps linearly to duration
-    max_steps = max(50, int(duration * 50))
-    audio = mg.generate(prompt, max_steps=max_steps)
-    # audio is mx.array in [-1, 1]; convert to int16 WAV
-    arr = np.array(mx.clip(audio, -1, 1))
-    pcm = (arr * 32767).astype(np.int16)
-    buf = io.BytesIO()
-    wavfile.write(buf, mg.sampling_rate, pcm)
-    return buf.getvalue()
-
-
 def music_musicgen_local(
     prompt: str,
     duration: int = 10,
@@ -969,18 +941,10 @@ def music_elevenlabs_sfx(
 
 def _music_one(provider: str, prompt: str, model: Optional[str], duration: int, api_key: Optional[str]) -> dict:
     p = (provider or "").lower()
-    if p in ("local", "musicgen", "transformers", "meta", "mlx", "apple"):
-        # Pick the best local backend for this machine: MLX on Apple Silicon,
-        # CUDA/CPU via transformers elsewhere.
-        try:
-            import mlx.core as _mx  # noqa: F401
-            m = model or "facebook/musicgen-medium"
-            return {"audio": music_musicgen_mlx(prompt, duration=duration, model=m),
-                    "format": "wav", "provider": "musicgen-local-mlx", "model": m}
-        except ImportError:
-            m = model or "facebook/musicgen-small"
-            return {"audio": music_musicgen_local(prompt, duration=duration, model=m),
-                    "format": "wav", "provider": "musicgen-local-torch", "model": m}
+    if p in ("local", "musicgen", "transformers", "meta"):
+        m = model or "facebook/musicgen-small"
+        return {"audio": music_musicgen_local(prompt, duration=duration, model=m),
+                "format": "wav", "provider": "musicgen-local", "model": m}
     if p in ("replicate",):
         m = model or "meta/musicgen"
         return {"audio": music_replicate(prompt, duration=duration, model=m, api_key=api_key),

--- a/npcpy/gen/audio_gen.py
+++ b/npcpy/gen/audio_gen.py
@@ -805,3 +805,223 @@ def audio_to_base64(audio_data: bytes) -> str:
 def base64_to_audio(b64_string: str) -> bytes:
     """Decode base64 string to audio bytes."""
     return base64.b64decode(b64_string)
+
+
+# ─── Music generation ─────────────────────────────────────────────────
+
+def music_musicgen_mlx(
+    prompt: str,
+    duration: int = 10,
+    model: str = "facebook/musicgen-medium",
+) -> bytes:
+    """Generate music natively on Apple Silicon via MLX.
+
+    Uses Apple's mlx-examples MusicGen port (vendored into npcpy.gen.mlx_musicgen).
+    Runs on the Apple GPU via MLX — no CUDA/MPS/CPU fallback needed.
+    Returns WAV bytes at 32 kHz.
+    """
+    import numpy as np
+    import scipy.io.wavfile as wavfile
+    import mlx.core as mx
+    from npcpy.gen.mlx_musicgen.musicgen import MusicGen
+
+    mg = MusicGen.from_pretrained(model)
+    # MusicGen's MLX port uses ~50 tokens/sec; max_steps maps linearly to duration
+    max_steps = max(50, int(duration * 50))
+    audio = mg.generate(prompt, max_steps=max_steps)
+    # audio is mx.array in [-1, 1]; convert to int16 WAV
+    arr = np.array(mx.clip(audio, -1, 1))
+    pcm = (arr * 32767).astype(np.int16)
+    buf = io.BytesIO()
+    wavfile.write(buf, mg.sampling_rate, pcm)
+    return buf.getvalue()
+
+
+def music_musicgen_local(
+    prompt: str,
+    duration: int = 10,
+    model: str = "facebook/musicgen-small",
+) -> bytes:
+    """Generate music locally with Meta MusicGen via transformers.
+
+    Returns WAV bytes (MusicGen outputs at 32 kHz).
+    """
+    import numpy as np
+    import scipy.io.wavfile as wavfile
+    import torch
+    # Use concrete classes to sidestep AutoProcessor's auto-discovery path.
+    from transformers import MusicgenProcessor, MusicgenForConditionalGeneration
+
+    processor = MusicgenProcessor.from_pretrained(model)
+    mg = MusicgenForConditionalGeneration.from_pretrained(model)
+
+    # MusicGen is numerically unstable on MPS (produces NaN/inf probs during
+    # sampling) — stick to CUDA or CPU.
+    if torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+    mg = mg.to(device)
+    mg.eval()
+
+    inputs = processor(text=[prompt], padding=True, return_tensors="pt").to(device)
+
+    # MusicGen uses ~50 tokens/sec at 32 kHz
+    max_new_tokens = int(duration * 50)
+
+    with torch.no_grad():
+        audio_values = mg.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=True, guidance_scale=3.0)
+
+    sample_rate = mg.config.audio_encoder.sampling_rate
+    arr = audio_values[0, 0].detach().cpu().numpy()
+    # normalize to int16
+    arr = np.clip(arr, -1.0, 1.0)
+    pcm = (arr * 32767).astype(np.int16)
+
+    buf = io.BytesIO()
+    wavfile.write(buf, sample_rate, pcm)
+    return buf.getvalue()
+
+
+def music_replicate(
+    prompt: str,
+    duration: int = 10,
+    model: str = "meta/musicgen",
+    version: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> bytes:
+    """Generate music via Replicate. Works with musicgen, stable-audio, riffusion."""
+    import requests
+
+    api_key = api_key or os.environ.get("REPLICATE_API_TOKEN") or os.environ.get("REPLICATE_API_KEY")
+    if not api_key:
+        raise RuntimeError("REPLICATE_API_TOKEN env var required for Replicate music generation")
+
+    # Resolve model → latest version automatically if not given.
+    if not version:
+        owner_model = model
+        r = requests.get(
+            f"https://api.replicate.com/v1/models/{owner_model}",
+            headers={"Authorization": f"Token {api_key}"},
+            timeout=30,
+        )
+        r.raise_for_status()
+        version = r.json()["latest_version"]["id"]
+
+    inputs: dict = {"prompt": prompt, "duration": duration}
+    if "stable-audio" in model:
+        inputs = {"prompt": prompt, "seconds_total": duration}
+    elif "riffusion" in model:
+        inputs = {"prompt_a": prompt}
+
+    create = requests.post(
+        "https://api.replicate.com/v1/predictions",
+        headers={"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
+        json={"version": version, "input": inputs},
+        timeout=30,
+    )
+    create.raise_for_status()
+    pred = create.json()
+    poll_url = pred["urls"]["get"]
+
+    import time
+    for _ in range(180):  # up to ~6 minutes
+        p = requests.get(poll_url, headers={"Authorization": f"Token {api_key}"}, timeout=30).json()
+        status = p.get("status")
+        if status == "succeeded":
+            out = p.get("output")
+            audio_url = out[0] if isinstance(out, list) else out
+            return requests.get(audio_url, timeout=120).content
+        if status in ("failed", "canceled"):
+            raise RuntimeError(f"Replicate prediction {status}: {p.get('error')}")
+        time.sleep(2)
+    raise TimeoutError("Replicate music generation timed out")
+
+
+def music_elevenlabs_sfx(
+    prompt: str,
+    duration: float = 10.0,
+    api_key: Optional[str] = None,
+) -> bytes:
+    """Generate a short sound effect / music clip via ElevenLabs sound-generation API."""
+    import requests
+
+    api_key = api_key or os.environ.get("ELEVENLABS_API_KEY")
+    if not api_key:
+        raise RuntimeError("ELEVENLABS_API_KEY env var required for ElevenLabs sound generation")
+
+    # ElevenLabs caps sound-generation at 22 seconds.
+    duration = max(0.5, min(22.0, float(duration)))
+
+    r = requests.post(
+        "https://api.elevenlabs.io/v1/sound-generation",
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+        json={
+            "text": prompt,
+            "duration_seconds": duration,
+            "prompt_influence": 0.3,
+        },
+        timeout=180,
+    )
+    r.raise_for_status()
+    return r.content  # MP3 bytes
+
+
+def _music_one(provider: str, prompt: str, model: Optional[str], duration: int, api_key: Optional[str]) -> dict:
+    p = (provider or "").lower()
+    if p in ("local", "musicgen", "transformers", "meta", "mlx", "apple"):
+        # Pick the best local backend for this machine: MLX on Apple Silicon,
+        # CUDA/CPU via transformers elsewhere.
+        try:
+            import mlx.core as _mx  # noqa: F401
+            m = model or "facebook/musicgen-medium"
+            return {"audio": music_musicgen_mlx(prompt, duration=duration, model=m),
+                    "format": "wav", "provider": "musicgen-local-mlx", "model": m}
+        except ImportError:
+            m = model or "facebook/musicgen-small"
+            return {"audio": music_musicgen_local(prompt, duration=duration, model=m),
+                    "format": "wav", "provider": "musicgen-local-torch", "model": m}
+    if p in ("replicate",):
+        m = model or "meta/musicgen"
+        return {"audio": music_replicate(prompt, duration=duration, model=m, api_key=api_key),
+                "format": "wav", "provider": "replicate", "model": m}
+    if p in ("elevenlabs", "stability", "11labs"):
+        return {"audio": music_elevenlabs_sfx(prompt, duration=duration, api_key=api_key),
+                "format": "mp3", "provider": "elevenlabs", "model": "sound-generation"}
+    raise ValueError(f"Unknown music provider: {provider!r}")
+
+
+def generate_music(
+    prompt: str,
+    provider: str = "replicate",
+    model: Optional[str] = None,
+    duration: int = 10,
+    api_key: Optional[str] = None,
+) -> dict:
+    """Unified music-generation entry point with automatic provider fallback.
+
+    Tries the requested provider first; on failure, walks the other providers
+    that have credentials available so the user always gets audio back.
+    """
+    requested = (provider or "local").lower()
+    order = [requested]
+    for cand in ("local", "replicate", "elevenlabs"):
+        if cand not in order:
+            order.append(cand)
+
+    errors: list[str] = []
+    for prov in order:
+        # Skip cloud providers that have no credentials configured.
+        if prov == "replicate" and not (api_key or os.environ.get("REPLICATE_API_TOKEN") or os.environ.get("REPLICATE_API_KEY")):
+            errors.append(f"{prov}: no REPLICATE_API_TOKEN")
+            continue
+        if prov in ("elevenlabs", "11labs", "stability") and not (api_key or os.environ.get("ELEVENLABS_API_KEY")):
+            errors.append(f"{prov}: no ELEVENLABS_API_KEY")
+            continue
+        try:
+            return _music_one(prov, prompt, model if prov == requested else None, duration, api_key)
+        except Exception as e:
+            errors.append(f"{prov}: {e}")
+            continue
+
+    raise RuntimeError("All music providers failed:\n  - " + "\n  - ".join(errors))

--- a/npcpy/gen/image_gen.py
+++ b/npcpy/gen/image_gen.py
@@ -196,19 +196,21 @@ def openai_image_gen(
 
     collected_images = []
     for item_data in result.data:
-        if model == 'gpt-image-1':
-            image_base64 = item_data.b64_json
-            image_bytes = base64.b64decode(image_base64)
+        b64 = getattr(item_data, 'b64_json', None)
+        url = getattr(item_data, 'url', None)
+        if b64:
+            image_bytes = base64.b64decode(b64)
             image = Image.open(io.BytesIO(image_bytes))
-        elif model == 'dall-e-2' or model == 'dall-e-3':
-            image_url = item_data.url
-            response = requests.get(image_url)
+        elif url:
+            response = requests.get(url)
             response.raise_for_status()
             image = Image.open(io.BytesIO(response.content))
         else:
-            image = item_data
+            raise ValueError(
+                f"OpenAI image response had neither b64_json nor url for model={model}: {item_data!r}"
+            )
         collected_images.append(image)
-        
+
     return collected_images
 
 def gemini_image_gen(

--- a/npcpy/gen/mlx_musicgen/encodec.py
+++ b/npcpy/gen/mlx_musicgen/encodec.py
@@ -1,0 +1,741 @@
+# Copyright © 2024 Apple Inc.
+
+import functools
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+_lstm_kernel = mx.fast.metal_kernel(
+    name="lstm",
+    input_names=["x", "h_in", "cell", "hidden_size", "time_step", "num_time_steps"],
+    output_names=["hidden_state", "cell_state"],
+    header="""
+    template <typename T>
+    T sigmoid(T x) {
+        auto y = 1 / (1 + metal::exp(-metal::abs(x)));
+        return (x < 0) ? 1 - y : y;
+    }
+    """,
+    source="""
+        uint b = thread_position_in_grid.x;
+        uint d = hidden_size * 4;
+
+        uint elem = b * d + thread_position_in_grid.y;
+        uint index = elem;
+        uint x_index = b * num_time_steps * d + time_step * d + index;
+
+        auto i = sigmoid(h_in[index] + x[x_index]);
+        index += hidden_size;
+        x_index += hidden_size;
+        auto f = sigmoid(h_in[index] + x[x_index]);
+        index += hidden_size;
+        x_index += hidden_size;
+        auto g = metal::precise::tanh(h_in[index] + x[x_index]);
+        index += hidden_size;
+        x_index += hidden_size;
+        auto o = sigmoid(h_in[index] + x[x_index]);
+
+        cell_state[elem] = f * cell[elem] + i * g;
+        hidden_state[elem] = o * metal::precise::tanh(cell_state[elem]);
+    """,
+)
+
+
+def lstm_custom(x, h_in, cell, time_step):
+    assert x.ndim == 3, "Input to LSTM must have 3 dimensions."
+    out_shape = cell.shape
+    return _lstm_kernel(
+        inputs=[x, h_in, cell, out_shape[-1], time_step, x.shape[-2]],
+        output_shapes=[out_shape, out_shape],
+        output_dtypes=[h_in.dtype, h_in.dtype],
+        grid=(x.shape[0], h_in.size // 4, 1),
+        threadgroup=(256, 1, 1),
+    )
+
+
+class LSTM(nn.Module):
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+    ):
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.Wx = mx.zeros((4 * hidden_size, input_size))
+        self.Wh = mx.zeros((4 * hidden_size, hidden_size))
+        self.bias = mx.zeros((4 * hidden_size,)) if bias else None
+
+    def __call__(self, x, hidden=None, cell=None):
+        if self.bias is not None:
+            x = mx.addmm(self.bias, x, self.Wx.T)
+        else:
+            x = x @ self.Wx.T
+
+        all_hidden = []
+
+        B = x.shape[0]
+        cell = cell or mx.zeros((B, self.hidden_size), x.dtype)
+        for t in range(x.shape[-2]):
+            if hidden is None:
+                hidden = mx.zeros((B, self.hidden_size * 4), x.dtype)
+            else:
+                hidden = hidden @ self.Wh.T
+            hidden, cell = lstm_custom(x, hidden, cell, t)
+            all_hidden.append(hidden)
+
+        return mx.stack(all_hidden, axis=-2)
+
+
+class EncodecConv1d(nn.Module):
+    """Conv1d with asymmetric or causal padding and normalization."""
+
+    def __init__(
+        self,
+        config,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        self.causal = config.use_causal_conv
+        self.pad_mode = config.pad_mode
+        self.norm_type = config.norm_type
+
+        self.conv = nn.Conv1d(
+            in_channels, out_channels, kernel_size, stride, dilation=dilation
+        )
+        if self.norm_type == "time_group_norm":
+            self.norm = nn.GroupNorm(1, out_channels, pytorch_compatible=True)
+
+        self.stride = stride
+
+        # Effective kernel size with dilations.
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+
+        self.padding_total = kernel_size - stride
+
+    def _get_extra_padding_for_conv1d(
+        self,
+        hidden_states: mx.array,
+    ) -> mx.array:
+        length = hidden_states.shape[1]
+        n_frames = (length - self.kernel_size + self.padding_total) / self.stride + 1
+        n_frames = int(math.ceil(n_frames)) - 1
+        ideal_length = n_frames * self.stride + self.kernel_size - self.padding_total
+        return ideal_length - length
+
+    def _pad1d(
+        self,
+        hidden_states: mx.array,
+        paddings: Tuple[int, int],
+        mode: str = "zero",
+        value: float = 0.0,
+    ):
+        if mode != "reflect":
+            return mx.pad(
+                hidden_states, paddings, mode="constant", constant_values=value
+            )
+
+        length = hidden_states.shape[1]
+        prefix = hidden_states[:, 1 : paddings[0] + 1][:, ::-1]
+        suffix = hidden_states[:, max(length - (paddings[1] + 1), 0) : -1][:, ::-1]
+        return mx.concatenate([prefix, hidden_states, suffix], axis=1)
+
+    def __call__(self, hidden_states):
+        extra_padding = self._get_extra_padding_for_conv1d(hidden_states)
+
+        if self.causal:
+            # Left padding for causal
+            hidden_states = self._pad1d(
+                hidden_states, (self.padding_total, extra_padding), mode=self.pad_mode
+            )
+        else:
+            # Asymmetric padding required for odd strides
+            padding_right = self.padding_total // 2
+            padding_left = self.padding_total - padding_right
+            hidden_states = self._pad1d(
+                hidden_states,
+                (padding_left, padding_right + extra_padding),
+                mode=self.pad_mode,
+            )
+
+        hidden_states = self.conv(hidden_states)
+
+        if self.norm_type == "time_group_norm":
+            hidden_states = self.norm(hidden_states)
+
+        return hidden_states
+
+
+class EncodecConvTranspose1d(nn.Module):
+    """ConvTranspose1d with asymmetric or causal padding and normalization."""
+
+    def __init__(
+        self,
+        config,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+    ):
+        super().__init__()
+        self.causal = config.use_causal_conv
+        self.trim_right_ratio = config.trim_right_ratio
+        self.norm_type = config.norm_type
+        self.conv = nn.ConvTranspose1d(in_channels, out_channels, kernel_size, stride)
+        if config.norm_type == "time_group_norm":
+            self.norm = nn.GroupNorm(1, out_channels, pytorch_compatible=True)
+        self.padding_total = kernel_size - stride
+
+    def __call__(self, hidden_states):
+        hidden_states = self.conv(hidden_states)
+
+        if self.norm_type == "time_group_norm":
+            hidden_states = self.norm(hidden_states)
+
+        if self.causal:
+            padding_right = math.ceil(self.padding_total * self.trim_right_ratio)
+        else:
+            padding_right = self.padding_total // 2
+
+        padding_left = self.padding_total - padding_right
+
+        end = hidden_states.shape[1] - padding_right
+        hidden_states = hidden_states[:, padding_left:end, :]
+        return hidden_states
+
+
+class EncodecLSTM(nn.Module):
+    def __init__(self, config, dimension):
+        super().__init__()
+        self.lstm = [LSTM(dimension, dimension) for _ in range(config.num_lstm_layers)]
+
+    def __call__(self, hidden_states):
+        h = hidden_states
+        for lstm in self.lstm:
+            h = lstm(h)
+        return h + hidden_states
+
+
+class EncodecResnetBlock(nn.Module):
+    """
+    Residual block from SEANet model as used by EnCodec.
+    """
+
+    def __init__(self, config, dim: int, dilations: List[int]):
+        super().__init__()
+        kernel_sizes = (config.residual_kernel_size, 1)
+        if len(kernel_sizes) != len(dilations):
+            raise ValueError("Number of kernel sizes should match number of dilations")
+
+        hidden = dim // config.compress
+        block = []
+        for i, (kernel_size, dilation) in enumerate(zip(kernel_sizes, dilations)):
+            in_chs = dim if i == 0 else hidden
+            out_chs = dim if i == len(kernel_sizes) - 1 else hidden
+            block += [nn.ELU()]
+            block += [
+                EncodecConv1d(config, in_chs, out_chs, kernel_size, dilation=dilation)
+            ]
+        self.block = block
+
+        if getattr(config, "use_conv_shortcut", True):
+            self.shortcut = EncodecConv1d(config, dim, dim, kernel_size=1)
+        else:
+            self.shortcut = nn.Identity()
+
+    def __call__(self, hidden_states):
+        residual = hidden_states
+        for layer in self.block:
+            hidden_states = layer(hidden_states)
+
+        return self.shortcut(residual) + hidden_states
+
+
+class EncodecEncoder(nn.Module):
+    """SEANet encoder as used by EnCodec."""
+
+    def __init__(self, config):
+        super().__init__()
+        model = [
+            EncodecConv1d(
+                config, config.audio_channels, config.num_filters, config.kernel_size
+            )
+        ]
+        scaling = 1
+
+        for ratio in reversed(config.upsampling_ratios):
+            current_scale = scaling * config.num_filters
+            for j in range(config.num_residual_layers):
+                model += [
+                    EncodecResnetBlock(
+                        config, current_scale, [config.dilation_growth_rate**j, 1]
+                    )
+                ]
+            model += [nn.ELU()]
+            model += [
+                EncodecConv1d(
+                    config,
+                    current_scale,
+                    current_scale * 2,
+                    kernel_size=ratio * 2,
+                    stride=ratio,
+                )
+            ]
+            scaling *= 2
+
+        model += [EncodecLSTM(config, scaling * config.num_filters)]
+        model += [nn.ELU()]
+        model += [
+            EncodecConv1d(
+                config,
+                scaling * config.num_filters,
+                config.hidden_size,
+                config.last_kernel_size,
+            )
+        ]
+
+        self.layers = model
+
+    def __call__(self, hidden_states):
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class EncodecDecoder(nn.Module):
+    """SEANet decoder as used by EnCodec."""
+
+    def __init__(self, config):
+        super().__init__()
+        scaling = int(2 ** len(config.upsampling_ratios))
+        model = [
+            EncodecConv1d(
+                config,
+                config.hidden_size,
+                scaling * config.num_filters,
+                config.kernel_size,
+            )
+        ]
+
+        model += [EncodecLSTM(config, scaling * config.num_filters)]
+
+        for ratio in config.upsampling_ratios:
+            current_scale = scaling * config.num_filters
+            model += [nn.ELU()]
+            model += [
+                EncodecConvTranspose1d(
+                    config,
+                    current_scale,
+                    current_scale // 2,
+                    kernel_size=ratio * 2,
+                    stride=ratio,
+                )
+            ]
+            for j in range(config.num_residual_layers):
+                model += [
+                    EncodecResnetBlock(
+                        config, current_scale // 2, (config.dilation_growth_rate**j, 1)
+                    )
+                ]
+            scaling //= 2
+
+        model += [nn.ELU()]
+        model += [
+            EncodecConv1d(
+                config,
+                config.num_filters,
+                config.audio_channels,
+                config.last_kernel_size,
+            )
+        ]
+        self.layers = model
+
+    def __call__(self, hidden_states):
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class EncodecEuclideanCodebook(nn.Module):
+    """Codebook with Euclidean distance."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.embed = mx.zeros((config.codebook_size, config.codebook_dim))
+
+    def quantize(self, hidden_states):
+        embed = self.embed.T
+        scaled_states = hidden_states.square().sum(axis=1, keepdims=True)
+        dist = -(
+            scaled_states
+            - 2 * hidden_states @ embed
+            + embed.square().sum(axis=0, keepdims=True)
+        )
+        embed_ind = dist.argmax(axis=-1)
+        return embed_ind
+
+    def encode(self, hidden_states):
+        shape = hidden_states.shape
+        hidden_states = hidden_states.reshape((-1, shape[-1]))
+        embed_ind = self.quantize(hidden_states)
+        embed_ind = embed_ind.reshape(*shape[:-1])
+        return embed_ind
+
+    def decode(self, embed_ind):
+        return self.embed[embed_ind]
+
+
+class EncodecVectorQuantization(nn.Module):
+    """
+    Vector quantization implementation. Currently supports only euclidean distance.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.codebook = EncodecEuclideanCodebook(config)
+
+    def encode(self, hidden_states):
+        return self.codebook.encode(hidden_states)
+
+    def decode(self, embed_ind):
+        return self.codebook.decode(embed_ind)
+
+
+class EncodecResidualVectorQuantizer(nn.Module):
+    """Residual Vector Quantizer."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.codebook_size = config.codebook_size
+
+        hop_length = np.prod(config.upsampling_ratios)
+        self.frame_rate = math.ceil(config.sampling_rate / hop_length)
+        self.num_quantizers = int(
+            1000 * config.target_bandwidths[-1] // (self.frame_rate * 10)
+        )
+        self.layers = [
+            EncodecVectorQuantization(config) for _ in range(self.num_quantizers)
+        ]
+
+    def get_num_quantizers_for_bandwidth(
+        self, bandwidth: Optional[float] = None
+    ) -> int:
+        """Return num_quantizers based on specified target bandwidth."""
+        bw_per_q = math.log2(self.codebook_size) * self.frame_rate
+        num_quantizers = self.num_quantizers
+        if bandwidth is not None and bandwidth > 0.0:
+            num_quantizers = int(max(1, math.floor(bandwidth * 1000 / bw_per_q)))
+        return num_quantizers
+
+    def encode(
+        self, embeddings: mx.array, bandwidth: Optional[float] = None
+    ) -> mx.array:
+        """
+        Encode a given input array with the specified frame rate at the given
+        bandwidth. The RVQ encode method sets the appropriate number of
+        quantizers to use and returns indices for each quantizer.
+        """
+        num_quantizers = self.get_num_quantizers_for_bandwidth(bandwidth)
+        residual = embeddings
+        all_indices = []
+        for layer in self.layers[:num_quantizers]:
+            indices = layer.encode(residual)
+            quantized = layer.decode(indices)
+            residual = residual - quantized
+            all_indices.append(indices)
+        out_indices = mx.stack(all_indices, axis=1)
+        return out_indices
+
+    def decode(self, codes: mx.array) -> mx.array:
+        """Decode the given codes to the quantized representation."""
+        quantized_out = None
+        for i, indices in enumerate(codes.split(codes.shape[1], axis=1)):
+            layer = self.layers[i]
+            quantized = layer.decode(indices.squeeze(1))
+            if quantized_out is None:
+                quantized_out = quantized
+            else:
+                quantized_out = quantized + quantized_out
+        return quantized_out
+
+
+class EncodecModel(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.encoder = EncodecEncoder(config)
+        self.decoder = EncodecDecoder(config)
+        self.quantizer = EncodecResidualVectorQuantizer(config)
+
+    def _encode_frame(
+        self, input_values: mx.array, bandwidth: float, padding_mask: mx.array
+    ) -> Tuple[mx.array, Optional[mx.array]]:
+        """
+        Encodes the given input using the underlying VQVAE.
+        """
+        length = input_values.shape[1]
+        duration = length / self.config.sampling_rate
+
+        if (
+            self.config.chunk_length_s is not None
+            and duration > 1e-5 + self.config.chunk_length_s
+        ):
+            raise RuntimeError(
+                f"Duration of frame ({duration}) is longer than chunk {self.config.chunk_length_s}"
+            )
+
+        scale = None
+        if self.config.normalize:
+            # if the padding is non zero
+            input_values = input_values * padding_mask[..., None]
+            mono = mx.sum(input_values, axis=2, keepdims=True) / input_values.shape[2]
+            scale = mono.square().mean(axis=1, keepdims=True).sqrt() + 1e-8
+            input_values = input_values / scale
+
+        embeddings = self.encoder(input_values)
+        codes = self.quantizer.encode(embeddings, bandwidth)
+        return codes, scale
+
+    def encode(
+        self,
+        input_values: mx.array,
+        padding_mask: mx.array = None,
+        bandwidth: Optional[float] = None,
+    ) -> Tuple[mx.array, Optional[mx.array]]:
+        """
+        Encodes the input audio waveform into discrete codes.
+
+        Args:
+            input_values (mx.array): The input audio waveform with shape
+                ``(batch_size, channels, sequence_length)``.
+            padding_mask (mx.array): Padding mask used to pad the ``input_values``.
+            bandwidth (float, optional): The target bandwidth. Must be one of
+                ``config.target_bandwidths``. If ``None``, uses the smallest
+                possible bandwidth. bandwidth is represented as a thousandth of
+                what it is, e.g. 6kbps bandwidth is represented as bandwidth == 6.0
+
+        Returns:
+            A list of frames containing the discrete encoded codes for the
+            input audio waveform, along with rescaling factors for each chunk
+            when ``config.normalize==True``. Each frame is a tuple ``(codebook,
+            scale)``, with ``codebook`` of shape ``(batch_size, num_codebooks,
+            frames)``.
+        """
+
+        if bandwidth is None:
+            bandwidth = self.config.target_bandwidths[0]
+        if bandwidth not in self.config.target_bandwidths:
+            raise ValueError(
+                f"This model doesn't support the bandwidth {bandwidth}. "
+                f"Select one of {self.config.target_bandwidths}."
+            )
+
+        _, input_length, channels = input_values.shape
+
+        if channels < 1 or channels > 2:
+            raise ValueError(
+                f"Number of audio channels must be 1 or 2, but got {channels}"
+            )
+
+        chunk_length = self.chunk_length
+        if chunk_length is None:
+            chunk_length = input_length
+            stride = input_length
+        else:
+            stride = self.chunk_stride
+
+        if padding_mask is None:
+            padding_mask = mx.ones(input_values.shape[:2], dtype=mx.bool_)
+        encoded_frames = []
+        scales = []
+
+        step = chunk_length - stride
+        if (input_length % stride) != step:
+            raise ValueError(
+                "The input length is not properly padded for batched chunked "
+                "encoding. Make sure to pad the input correctly."
+            )
+
+        for offset in range(0, input_length - step, stride):
+            mask = padding_mask[:, offset : offset + chunk_length].astype(mx.bool_)
+            frame = input_values[:, offset : offset + chunk_length]
+            encoded_frame, scale = self._encode_frame(frame, bandwidth, mask)
+            encoded_frames.append(encoded_frame)
+            scales.append(scale)
+
+        encoded_frames = mx.stack(encoded_frames)
+
+        return (encoded_frames, scales)
+
+    @staticmethod
+    def _linear_overlap_add(frames: List[mx.array], stride: int):
+        if len(frames) == 0:
+            raise ValueError("`frames` cannot be an empty list.")
+
+        dtype = frames[0].dtype
+        N, frame_length, C = frames[0].shape
+        total_size = stride * (len(frames) - 1) + frames[-1].shape[1]
+
+        time_vec = mx.linspace(0, 1, frame_length + 2, dtype=dtype)[1:-1]
+        weight = 0.5 - (time_vec - 0.5).abs()
+
+        weight = weight[:, None]
+        sum_weight = mx.zeros((total_size, 1), dtype=dtype)
+        out = mx.zeros((N, total_size, C), dtype=dtype)
+        offset = 0
+
+        for frame in frames:
+            frame_length = frame.shape[1]
+            out[:, offset : offset + frame_length] += weight[:frame_length] * frame
+            sum_weight[offset : offset + frame_length] += weight[:frame_length]
+            offset += stride
+
+        return out / sum_weight
+
+    def _decode_frame(
+        self, codes: mx.array, scale: Optional[mx.array] = None
+    ) -> mx.array:
+        embeddings = self.quantizer.decode(codes)
+        outputs = self.decoder(embeddings)
+        if scale is not None:
+            outputs = outputs * scale
+        return outputs
+
+    @property
+    def channels(self):
+        return self.config.audio_channels
+
+    @property
+    def sampling_rate(self):
+        return self.config.sampling_rate
+
+    @property
+    def chunk_length(self):
+        if self.config.chunk_length_s is None:
+            return None
+        else:
+            return int(self.config.chunk_length_s * self.config.sampling_rate)
+
+    @property
+    def chunk_stride(self):
+        if self.config.chunk_length_s is None or self.config.overlap is None:
+            return None
+        else:
+            return max(1, int((1.0 - self.config.overlap) * self.chunk_length))
+
+    def decode(
+        self,
+        audio_codes: mx.array,
+        audio_scales: Union[mx.array, List[mx.array]],
+        padding_mask: Optional[mx.array] = None,
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Decodes the given frames into an output audio waveform.
+
+        Note that the output might be a bit bigger than the input. In that
+        case, any extra steps at the end should be trimmed.
+
+        Args:
+            audio_codes (mx.array): Discret code embeddings of shape
+                ``(batch_size, nb_chunks, chunk_length)``.
+            audio_scales (mx.array): Scaling factor for each input.
+            padding_mask (mx.array): Padding mask.
+        """
+        chunk_length = self.chunk_length
+        if chunk_length is None:
+            if audio_codes.shape[1] != 1:
+                raise ValueError(f"Expected one frame, got {len(audio_codes)}")
+            audio_values = self._decode_frame(audio_codes[:, 0], audio_scales[0])
+        else:
+            decoded_frames = []
+
+            for frame, scale in zip(audio_codes, audio_scales):
+                frames = self._decode_frame(frame, scale)
+                decoded_frames.append(frames)
+
+            audio_values = self._linear_overlap_add(
+                decoded_frames, self.chunk_stride or 1
+            )
+
+        # truncate based on padding mask
+        if padding_mask is not None and padding_mask.shape[1] < audio_values.shape[1]:
+            audio_values = audio_values[:, : padding_mask.shape[1]]
+        return audio_values
+
+    @classmethod
+    def from_pretrained(cls, path_or_repo: str):
+        from huggingface_hub import snapshot_download
+
+        path = Path(path_or_repo)
+        if not path.exists():
+            path = Path(
+                snapshot_download(
+                    repo_id=path_or_repo,
+                    allow_patterns=["*.json", "*.safetensors", "*.model"],
+                )
+            )
+
+        with open(path / "config.json", "r") as f:
+            config = SimpleNamespace(**json.load(f))
+
+        model = EncodecModel(config)
+        model.load_weights(str(path / "model.safetensors"))
+        processor = functools.partial(
+            preprocess_audio,
+            sampling_rate=config.sampling_rate,
+            chunk_length=model.chunk_length,
+            chunk_stride=model.chunk_stride,
+        )
+        mx.eval(model)
+        return model, processor
+
+
+def preprocess_audio(
+    raw_audio: Union[mx.array, List[mx.array]],
+    sampling_rate: int = 24000,
+    chunk_length: Optional[int] = None,
+    chunk_stride: Optional[int] = None,
+):
+    r"""
+    Prepare inputs for the EnCodec model.
+
+    Args:
+        raw_audio (mx.array or List[mx.array]): The sequence or batch of
+            sequences to be processed.
+        sampling_rate (int): The sampling rate at which the audio waveform
+            should be digitalized.
+        chunk_length (int, optional): The model's chunk length.
+        chunk_stride (int, optional): The model's chunk stride.
+    """
+    if not isinstance(raw_audio, list):
+        raw_audio = [raw_audio]
+
+    raw_audio = [x[..., None] if x.ndim == 1 else x for x in raw_audio]
+
+    max_length = max(array.shape[0] for array in raw_audio)
+    if chunk_length is not None:
+        max_length += chunk_length - (max_length % chunk_stride)
+
+    inputs = []
+    masks = []
+    for x in raw_audio:
+        length = x.shape[0]
+        mask = mx.ones((length,), dtype=mx.bool_)
+        difference = max_length - length
+        if difference > 0:
+            mask = mx.pad(mask, (0, difference))
+            x = mx.pad(x, ((0, difference), (0, 0)))
+        inputs.append(x)
+        masks.append(mask)
+    return mx.stack(inputs), mx.stack(masks)

--- a/npcpy/gen/mlx_musicgen/musicgen.py
+++ b/npcpy/gen/mlx_musicgen/musicgen.py
@@ -1,0 +1,358 @@
+# Copyright © 2024 Apple Inc.
+
+import json
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from tqdm import tqdm
+
+from .encodec import EncodecModel
+from .t5 import T5
+
+
+class TextConditioner(nn.Module):
+    def __init__(self, t5_name, input_dim, output_dim):
+        super().__init__()
+        self._t5, self.tokenizer = T5.from_pretrained(t5_name)
+        self.output_proj = nn.Linear(input_dim, output_dim)
+
+    def __call__(self, text):
+        x = self.tokenizer.encode(text)
+        x = self._t5.encode(x)
+        return self.output_proj(x)
+
+
+class KVCache:
+    def __init__(self, head_dim, n_kv_heads):
+        self.n_kv_heads = n_kv_heads
+        if isinstance(head_dim, int):
+            self.k_head_dim = self.v_head_dim = head_dim
+        elif isinstance(head_dim, tuple) and len(head_dim) == 2:
+            self.k_head_dim, self.v_head_dim = head_dim
+        else:
+            raise ValueError("head_dim must be an int or a tuple of two ints")
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.step = 256
+
+    def update_and_fetch(self, keys, values):
+        prev = self.offset
+        if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
+            B = keys.shape[0]
+            n_steps = (self.step + keys.shape[2] - 1) // self.step
+            k_shape = (B, self.n_kv_heads, n_steps * self.step, self.k_head_dim)
+            v_shape = (B, self.n_kv_heads, n_steps * self.step, self.v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        self.offset += keys.shape[2]
+        self.keys[..., prev : self.offset, :] = keys
+        self.values[..., prev : self.offset, :] = values
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(self, dim, n_heads):
+        super().__init__()
+
+        self.n_heads = n_heads
+
+        head_dim = dim // n_heads
+
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, dim, bias=False)
+        self.k_proj = nn.Linear(dim, dim, bias=False)
+        self.v_proj = nn.Linear(dim, dim, bias=False)
+        self.out_proj = nn.Linear(dim, dim, bias=False)
+
+    def __call__(
+        self,
+        queries: mx.array,
+        keys: mx.array,
+        values: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        B, L_q, D = queries.shape
+        L_k = keys.shape[1]
+
+        queries, keys, values = (
+            self.q_proj(queries),
+            self.k_proj(keys),
+            self.v_proj(values),
+        )
+
+        # Prepare the queries, keys and values for the attention computation
+        queries = queries.reshape(B, L_q, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L_k, self.n_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L_k, self.n_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L_q, -1)
+        return self.out_proj(output)
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.num_attention_heads = config.decoder.num_attention_heads
+        self.hidden_size = config.decoder.hidden_size
+        self.self_attn = MultiHeadAttention(self.hidden_size, self.num_attention_heads)
+        self.cross_attn = MultiHeadAttention(self.hidden_size, self.num_attention_heads)
+        self.linear1 = nn.Linear(self.hidden_size, config.decoder.ffn_dim, bias=False)
+        self.linear2 = nn.Linear(config.decoder.ffn_dim, self.hidden_size, bias=False)
+
+        self.norm1 = nn.LayerNorm(self.hidden_size, eps=1e-5)
+        self.norm_cross = nn.LayerNorm(self.hidden_size, eps=1e-5)
+        self.norm2 = nn.LayerNorm(self.hidden_size, eps=1e-5)
+
+    def __call__(
+        self,
+        x: mx.array,
+        conditioning: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        xn = self.norm1(x)
+        x += self.self_attn(xn, xn, xn, mask, cache)
+        xn = self.norm_cross(x)
+        x += self.cross_attn(xn, conditioning, conditioning, mask)
+        xn = self.norm2(x)
+        x += self.linear2(nn.gelu(self.linear1(xn)))
+        return x
+
+
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
+def top_k_sampling(
+    logits: mx.array, top_k: float, temperature: float, axis: int = -1
+) -> mx.array:
+    """
+    Apply top-k sampling to logits.
+
+    Args:
+        logits: The logits from the model's output.
+        top_k: Sample from the top k logits.
+        temperature: Temperature parameter for softmax distribution reshaping.
+        axis: Axis along which to sample.
+    Returns:
+        token selected based on the top-k criterion.
+    """
+    # referenced implementation from https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L449-L460
+    probs = mx.softmax(logits * (1 / temperature), axis=axis)
+
+    # sort probs in ascending order
+    sorted_indices = mx.argsort(probs, axis=axis)
+    sorted_probs = mx.take_along_axis(probs, sorted_indices, axis=axis)
+    prob_threshold = mx.take(sorted_probs, mx.array(-top_k), axis=axis)
+
+    # select the top K tokens in probability
+    top_probs = mx.where(
+        sorted_probs > prob_threshold,
+        sorted_probs,
+        0,
+    )
+
+    sorted_token = mx.random.categorical(mx.log(top_probs), axis=axis)
+    token = mx.take_along_axis(
+        sorted_indices, mx.expand_dims(sorted_token, axis), axis=axis
+    )
+
+    return token
+
+
+def create_sin_embedding(positions: mx.array, dim: int, max_period: float = 10000):
+    assert dim % 2 == 0
+    half_dim = dim // 2
+    adim = mx.arange(half_dim).reshape(1, 1, -1)
+    phase = positions / (max_period ** (adim / (half_dim - 1)))
+    return mx.concatenate([mx.cos(phase), mx.sin(phase)], axis=-1)
+
+
+class MusicGen(nn.Module):
+    def __init__(self, config):
+        self.num_codebooks = config.decoder.num_codebooks
+        self.codebook_size = config.audio_encoder.codebook_size
+        self.bos_token_id = config.decoder.bos_token_id
+        self.hidden_size = config.decoder.hidden_size
+        self.num_attention_heads = config.decoder.num_attention_heads
+        self.sampling_rate = config.audio_encoder.sampling_rate
+
+        self.text_conditioner = TextConditioner(
+            config.text_encoder._name_or_path,
+            config.text_encoder.d_model,
+            self.hidden_size,
+        )
+        self.emb = [
+            nn.Embedding(self.codebook_size + 1, self.hidden_size)
+            for _ in range(self.num_codebooks)
+        ]
+        self.layers = [
+            TransformerBlock(config) for _ in range(config.decoder.num_hidden_layers)
+        ]
+        self.out_norm = nn.LayerNorm(self.hidden_size, eps=1e-5)
+        self.linears = [
+            nn.Linear(self.hidden_size, self.codebook_size, bias=False)
+            for _ in range(self.num_codebooks)
+        ]
+        encodec_name = config.audio_encoder._name_or_path.split("/")[-1]
+        encodec_name = encodec_name.replace("_", "-")
+        self._audio_decoder, _ = EncodecModel.from_pretrained(
+            f"mlx-community/{encodec_name}-float32"
+        )
+
+    def __call__(
+        self,
+        audio_tokens: mx.array,
+        conditioning: mx.array,
+        cache: list[KVCache] = None,
+    ):
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        x = sum([self.emb[k](audio_tokens[..., k]) for k in range(self.num_codebooks)])
+
+        offset = cache[0].offset if cache[0] is not None else 0
+        pos_emb = create_sin_embedding(offset, self.hidden_size)
+        x += pos_emb.astype(x.dtype)
+
+        for layer, c in zip(self.layers, cache):
+            x = layer(x, conditioning, cache=c)
+
+        x = self.out_norm(x)
+        x = mx.stack([self.linears[k](x) for k in range(self.num_codebooks)], axis=-1)
+        return x
+
+    def generate(
+        self,
+        text: str,
+        max_steps: int = 200,
+        top_k: int = 250,
+        temp: float = 1.0,
+        guidance_coef: float = 3.0,
+    ) -> mx.array:
+        """
+        Generates a waveform conditioned on `text`.
+
+        Args:
+            text (str): The text to condition generation on.
+            max_steps (int): Max steps to generate.
+            top_k (int): Top k used in sampling.
+            temp (float): Sampling softmax temperature.
+            guidance_coef (float): Classifier free guidance coefficent.
+                Used to combine conditional and unconditional logits.
+
+        Returns:
+            An mx.array of audio samples of shape ``(num_samples,)``.
+        """
+        # Assuming no audio prompt we start with all bos token for the codebooks
+        audio_shape = (1, max_steps + 1, self.num_codebooks)
+        audio_seq = mx.full(audio_shape, self.bos_token_id)
+
+        text_tokens = self.text_conditioner(text)
+        # Compute conditional and unconditional logits in one batch
+        text_tokens = mx.concatenate([text_tokens, mx.zeros_like(text_tokens)], axis=0)
+
+        head_dim = self.hidden_size // self.num_attention_heads
+        cache = [
+            KVCache(head_dim, self.num_attention_heads) for _ in range(len(self.layers))
+        ]
+        for offset in tqdm(range(max_steps)):
+            audio_input = mx.tile(audio_seq[:, offset : offset + 1], [2, 1, 1])
+            audio_logits = self(audio_input, text_tokens, cache)
+            cond_logits, uncond_logits = audio_logits[:1], audio_logits[1:2]
+            audio_logits = uncond_logits + (cond_logits - uncond_logits) * guidance_coef
+            audio_tokens = top_k_sampling(audio_logits, top_k, temp, axis=-2)
+            # "delay" pattern
+            audio_tokens[..., offset + 1 :] = self.bos_token_id
+            audio_tokens[..., : -max_steps + offset] = self.bos_token_id
+            audio_seq[:, offset + 1 : offset + 2] = audio_tokens
+            mx.eval(audio_seq)
+
+        # Undo delay
+        for i in range(self.num_codebooks):
+            audio_seq[:, : -self.num_codebooks, i] = audio_seq[
+                :, i : -self.num_codebooks + i, i
+            ]
+        audio_seq = audio_seq[:, 1 : -self.num_codebooks + 1]
+
+        audio_seq = mx.swapaxes(audio_seq, -1, -2)[:, mx.newaxis]
+        audio = self._audio_decoder.decode(audio_seq, audio_scales=[None])
+        return audio[0]
+
+    @classmethod
+    def sanitize(cls, weights):
+        out_weights = {}
+        for k, arr in weights.items():
+            if k.startswith("transformer."):
+                k = k[len("transformer.") :]
+
+            if "cross_attention" in k:
+                k = k.replace("cross_attention", "cross_attn")
+
+            if "condition_provider" in k:
+                k = k.replace(
+                    "condition_provider.conditioners.description", "text_conditioner"
+                )
+
+            if "in_proj_weight" in k:
+                dim = arr.shape[0] // 3
+                name = "in_proj_weight"
+                out_weights[k.replace(name, "q_proj.weight")] = arr[:dim]
+                out_weights[k.replace(name, "k_proj.weight")] = arr[dim : dim * 2]
+                out_weights[k.replace(name, "v_proj.weight")] = arr[dim * 2 :]
+                continue
+
+            out_weights[k] = arr
+        return out_weights
+
+    @classmethod
+    def from_pretrained(cls, path_or_repo: str):
+        import torch
+        from huggingface_hub import snapshot_download
+
+        path = Path(path_or_repo)
+        if not path.exists():
+            path = Path(
+                snapshot_download(
+                    repo_id=path_or_repo,
+                    allow_patterns=["*.json", "state_dict.bin"],
+                )
+            )
+
+        with open(path / "config.json", "r") as f:
+            config = SimpleNamespace(**json.load(f))
+            config.text_encoder = SimpleNamespace(**config.text_encoder)
+            config.audio_encoder = SimpleNamespace(**config.audio_encoder)
+            config.decoder = SimpleNamespace(**config.decoder)
+
+        weights = torch.load(path / "state_dict.bin", weights_only=True)["best_state"]
+        weights = {k: mx.array(v) for k, v in weights.items()}
+        weights = cls.sanitize(weights)
+
+        model = MusicGen(config)
+        model.load_weights(list(weights.items()))
+        return model

--- a/npcpy/gen/mlx_musicgen/t5.py
+++ b/npcpy/gen/mlx_musicgen/t5.py
@@ -1,0 +1,523 @@
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter_ns
+from types import SimpleNamespace
+from typing import List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from transformers import AutoTokenizer
+
+
+class Tokenizer:
+    def __init__(self, config, model_name):
+        self._decoder_start_id = config.decoder_start_token_id
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_name,
+            legacy=False,
+            model_max_length=getattr(config, "n_positions", 512),
+        )
+
+    @property
+    def eos_id(self) -> int:
+        return self._tokenizer.eos_token_id
+
+    @property
+    def decoder_start_id(self) -> int:
+        return self._decoder_start_id
+
+    def encode(self, s: str) -> mx.array:
+        return mx.array(
+            self._tokenizer(
+                s,
+                return_tensors="np",
+                return_attention_mask=False,
+            )["input_ids"]
+        )
+
+    def decode(self, t: List[int], with_sep: bool = True) -> str:
+        tokens = self._tokenizer.convert_ids_to_tokens(t)
+        return "".join(t.replace("▁", " " if with_sep else "") for t in tokens)
+
+
+def _relative_position_bucket(
+    relative_position, bidirectional=True, num_buckets=32, max_distance=128
+):
+    """
+    Adapted from HF Tensorflow:
+    https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py
+
+    Translate relative position to a bucket number for relative attention. The relative position is defined as
+    memory_position - query_position, i.e. the distance in tokens from the attending position to the attended-to
+    position. If bidirectional=False, then positive relative positions are invalid. We use smaller buckets for
+    small absolute relative_position and larger buckets for larger absolute relative_positions. All relative
+    positions >=max_distance map to the same bucket. All relative positions <=-max_distance map to the same bucket.
+    This should allow for more graceful generalization to longer sequences than the model has been trained on
+
+    Args:
+        relative_position: an int32 Tensor
+        bidirectional: a boolean - whether the attention is bidirectional
+        num_buckets: an integer
+        max_distance: an integer
+
+    Returns:
+        a Tensor with the same shape as relative_position, containing int32 values in the range [0, num_buckets)
+    """
+    relative_buckets = 0
+    if bidirectional:
+        num_buckets //= 2
+        relative_buckets += (relative_position > 0).astype(mx.int16) * num_buckets
+        relative_position = mx.abs(relative_position)
+    else:
+        relative_position = -mx.minimum(
+            relative_position, mx.zeros_like(relative_position)
+        )
+    # now relative_position is in the range [0, inf)
+
+    # half of the buckets are for exact increments in positions
+    max_exact = num_buckets // 2
+    is_small = relative_position < max_exact
+
+    # The other half of the buckets are for logarithmically bigger bins in positions up to max_distance
+    scale = (num_buckets - max_exact) / np.log(max_distance / max_exact)
+    relative_position_if_large = max_exact + (
+        mx.log(relative_position.astype(mx.float32) / max_exact) * scale
+    ).astype(mx.int16)
+    relative_position_if_large = mx.minimum(relative_position_if_large, num_buckets - 1)
+    relative_buckets += mx.where(
+        is_small, relative_position, relative_position_if_large
+    )
+    return relative_buckets
+
+
+class RelativePositionBias(nn.Module):
+    def __init__(self, config, bidirectional: bool):
+        self.bidirectional = bidirectional
+        self.num_buckets = config.relative_attention_num_buckets
+        self.max_distance = getattr(config, "relative_attention_max_distance", 128)
+        self.n_heads = config.num_heads
+        self.embeddings = nn.Embedding(
+            config.relative_attention_num_buckets, config.num_heads
+        )
+
+    def __call__(self, query_length: int, key_length: int, offset: int = 0):
+        """Compute binned relative position bias"""
+        context_position = mx.arange(offset, query_length)[:, None]
+        memory_position = mx.arange(key_length)[None, :]
+
+        # shape (query_length, key_length)
+        relative_position = memory_position - context_position
+        relative_position_bucket = _relative_position_bucket(
+            relative_position,
+            bidirectional=self.bidirectional,
+            num_buckets=self.num_buckets,
+            max_distance=self.max_distance,
+        )
+
+        # shape (query_length, key_length, num_heads)
+        values = self.embeddings(relative_position_bucket)
+
+        # shape (num_heads, query_length, key_length)
+        return values.transpose(2, 0, 1)
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        inner_dim = config.d_kv * config.num_heads
+        self.num_heads = config.num_heads
+        self.query_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.key_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.value_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.out_proj = nn.Linear(inner_dim, config.d_model, bias=False)
+
+    def __call__(
+        self,
+        queries: mx.array,
+        keys: mx.array,
+        values: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Tuple[mx.array, mx.array]] = None,
+    ) -> [mx.array, Tuple[mx.array, mx.array]]:
+        queries = self.query_proj(queries)
+        keys = self.key_proj(keys)
+        values = self.value_proj(values)
+
+        num_heads = self.num_heads
+        B, L, _ = queries.shape
+        _, S, _ = keys.shape
+        queries = queries.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, S, num_heads, -1).transpose(0, 2, 3, 1)
+        values = values.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            key_cache, value_cache = cache
+            keys = mx.concatenate([key_cache, keys], axis=3)
+            values = mx.concatenate([value_cache, values], axis=2)
+
+        # Dimensions are [batch x num heads x sequence x hidden dim]
+        scores = queries @ keys
+        if mask is not None:
+            scores = scores + mask.astype(scores.dtype)
+
+        scores = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
+        values_hat = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.out_proj(values_hat), (keys, values)
+
+
+class DenseActivation(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        mlp_dims = config.d_ff or config.d_model * 4
+        self.gated = hasattr(config, "feed_forward_proj")
+        activation = (
+            "relu"
+            if not self.gated
+            else config.feed_forward_proj.removeprefix("gated-")
+        )
+        if self.gated:
+            self.wi_0 = nn.Linear(config.d_model, mlp_dims, bias=False)
+            self.wi_1 = nn.Linear(config.d_model, mlp_dims, bias=False)
+        else:
+            self.wi = nn.Linear(config.d_model, mlp_dims, bias=False)
+        self.wo = nn.Linear(mlp_dims, config.d_model, bias=False)
+        if activation == "relu":
+            self.act = nn.relu
+        elif activation == "gelu":
+            self.act = nn.gelu
+        elif activation == "silu":
+            self.act = nn.silu
+        else:
+            raise ValueError(f"Unknown activation: {activation}")
+
+    def __call__(self, x):
+        if self.gated:
+            hidden_act = self.act(self.wi_0(x))
+            hidden_linear = self.wi_1(x)
+            x = hidden_act * hidden_linear
+        else:
+            x = self.act(self.wi(x))
+        return self.wo(x)
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.attention = MultiHeadAttention(config)
+        self.ln1 = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln2 = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.dense = DenseActivation(config)
+
+    def __call__(self, x, mask):
+        y = self.ln1(x)
+        y, _ = self.attention(y, y, y, mask=mask)
+        x = x + y
+
+        y = self.ln2(x)
+        y = self.dense(y)
+        return x + y
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.layers = [
+            TransformerEncoderLayer(config) for i in range(config.num_layers)
+        ]
+        self.ln = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.relative_attention_bias = RelativePositionBias(config, bidirectional=True)
+
+    def __call__(self, x: mx.array):
+        pos_bias = self.relative_attention_bias(x.shape[1], x.shape[1])
+        for layer in self.layers:
+            x = layer(x, mask=pos_bias)
+        return self.ln(x)
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.self_attention = MultiHeadAttention(config)
+        self.cross_attention = MultiHeadAttention(config)
+        self.ln1 = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln2 = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln3 = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.dense = DenseActivation(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        memory: mx.array,
+        mask: mx.array,
+        memory_mask: mx.array,
+        cache: Optional[List[Tuple[mx.array, mx.array]]] = None,
+    ):
+        y = self.ln1(x)
+        y, cache = self.self_attention(y, y, y, mask, cache)
+        x = x + y
+
+        y = self.ln2(x)
+        y, _ = self.cross_attention(y, memory, memory, memory_mask)
+        x = x + y
+
+        y = self.ln3(x)
+        y = self.dense(y)
+        x = x + y
+
+        return x, cache
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        n_layers = getattr(config, "num_decoder_layers", config.num_layers)
+        self.layers = [TransformerDecoderLayer(config) for i in range(n_layers)]
+        self.ln = nn.RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.relative_attention_bias = RelativePositionBias(config, bidirectional=False)
+
+    def __call__(self, x, memory, mask, memory_mask, cache=None):
+        if cache is not None:
+            offset = cache[0][0].shape[3]
+        else:
+            offset = 0
+            cache = [None] * len(self.layers)
+
+        T = offset + x.shape[1]
+        pos_bias = self.relative_attention_bias(T, T, offset=offset)
+        if mask is not None:
+            mask += pos_bias
+        else:
+            mask = pos_bias
+
+        for e, layer in enumerate(self.layers):
+            x, cache[e] = layer(x, memory, mask, memory_mask, cache=cache[e])
+        x = self.ln(x)
+
+        return x, cache
+
+
+class OutputHead(nn.Module):
+    def __init__(self, config):
+        self.linear = nn.Linear(config.d_model, config.vocab_size, bias=False)
+
+    def __call__(self, inputs):
+        return self.linear(inputs)
+
+
+class T5(nn.Module):
+    def __init__(self, config):
+        self.wte = nn.Embedding(config.vocab_size, config.d_model)
+        self.encoder = TransformerEncoder(config)
+        self.decoder = TransformerDecoder(config)
+        self.tie_word_embeddings = getattr(config, "tie_word_embeddings", True)
+        if not self.tie_word_embeddings:
+            self.lm_head = OutputHead(config)
+        self.model_dim = config.d_model
+
+    def encode(self, inputs: mx.array):
+        return self.encoder(self.wte(inputs))
+
+    def decode(
+        self,
+        inputs: mx.array,
+        memory: mx.array,
+        cache=None,
+    ):
+        inputs = self.wte(inputs)
+        T = inputs.shape[1]
+        if T > 1:
+            mask = nn.MultiHeadAttention.create_additive_causal_mask(T)
+            mask = mask.astype(inputs.dtype)
+        else:
+            mask = None
+
+        y, cache = self.decoder(
+            inputs, memory=memory, mask=mask, memory_mask=None, cache=cache
+        )
+        if not self.tie_word_embeddings:
+            y = self.lm_head(y)
+        else:
+            y *= self.model_dim**-0.5
+            y = y @ self.wte.weight.T
+        return y, cache
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        decoder_inputs: mx.array,
+    ):
+        return self.decode(decoder_inputs, self.encode(inputs))[0]
+
+    @classmethod
+    def sanitize(cls, weights):
+        shared_replacement_patterns = [
+            (".block.", ".layers."),
+            (".k.", ".key_proj."),
+            (".o.", ".out_proj."),
+            (".q.", ".query_proj."),
+            (".v.", ".value_proj."),
+            ("shared.", "wte."),
+            ("lm_head.", "lm_head.linear."),
+            (".layer.0.layer_norm.", ".ln1."),
+            (".layer.1.layer_norm.", ".ln2."),
+            (".layer.2.layer_norm.", ".ln3."),
+            (".final_layer_norm.", ".ln."),
+            (
+                "layers.0.layer.0.SelfAttention.relative_attention_bias.",
+                "relative_attention_bias.embeddings.",
+            ),
+        ]
+
+        encoder_replacement_patterns = [
+            (".layer.0.SelfAttention.", ".attention."),
+            (".layer.1.DenseReluDense.", ".dense."),
+        ]
+
+        decoder_replacement_patterns = [
+            (".layer.0.SelfAttention.", ".self_attention."),
+            (".layer.1.EncDecAttention.", ".cross_attention."),
+            (".layer.2.DenseReluDense.", ".dense."),
+        ]
+
+        ignored_keys = [
+            "decoder.layers.0.cross_attention.relative_attention_bias.weight"
+        ]
+
+        def replace_key(key: str) -> str:
+            for old, new in shared_replacement_patterns:
+                key = key.replace(old, new)
+            if key.startswith("encoder."):
+                for old, new in encoder_replacement_patterns:
+                    key = key.replace(old, new)
+            elif key.startswith("decoder."):
+                for old, new in decoder_replacement_patterns:
+                    key = key.replace(old, new)
+            return key
+
+        weights = {replace_key(k): v for k, v in weights.items()}
+        for key in ignored_keys:
+            if key in weights:
+                del weights[key]
+        return weights
+
+    @classmethod
+    def from_pretrained(
+        cls, path_or_repo: str, dtype: mx.Dtype = mx.bfloat16
+    ) -> tuple["T5", Tokenizer]:
+        from huggingface_hub import snapshot_download
+
+        path = Path(path_or_repo)
+        if not path.exists():
+            path = Path(
+                snapshot_download(
+                    repo_id=path_or_repo,
+                    allow_patterns=["*.json", "*.safetensors", "*.model"],
+                )
+            )
+
+        with open(path / "config.json", "r") as f:
+            config = SimpleNamespace(**json.load(f))
+
+        model = T5(config)
+        weights = mx.load(str(path / "model.safetensors"))
+        weights = cls.sanitize(weights)
+        weights = {k: v.astype(dtype) for k, v in weights.items()}
+        model.load_weights(list(weights.items()))
+        return model, Tokenizer(config, "t5-base")
+
+
+def generate(prompt: str, model: T5, tokenizer: Tokenizer, temp: Optional[float] = 0.0):
+    def sample(logits):
+        if temp == 0:
+            return mx.argmax(logits, axis=-1)
+        else:
+            return mx.random.categorical(logits * (1 / temp))
+
+    prompt = tokenizer.encode(prompt)
+    decoder_inputs = mx.array([tokenizer.decoder_start_id])
+    memory = model.encode(prompt)
+    cache = None
+    y = decoder_inputs
+    while True:
+        logits, cache = model.decode(y[None], memory, cache=cache)
+        y = sample(logits[:, -1, :])
+        yield y.squeeze()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="T5 Inference script")
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="Name of the T5 model.",
+        default="t5-small",
+    )
+    parser.add_argument(
+        "--prompt",
+        help="",
+        default="translate English to German: That is good.",
+    )
+    parser.add_argument(
+        "--encode-only",
+        action="store_true",
+        default=False,
+        help="Whether to decode or not. If true, will output last layer of encoder.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        "-m",
+        type=int,
+        default=100,
+        help="Maximum number of tokens to generate",
+    )
+    parser.add_argument(
+        "--temp",
+        help="The sampling temperature.",
+        type=float,
+        default=0.0,
+    )
+    parser.add_argument(
+        "--dtype",
+        help="The model data type.",
+        type=str,
+        choices=["float16", "bfloat16", "float32"],
+        default="bfloat16",
+    )
+
+    parser.add_argument("--seed", type=int, default=0, help="The PRNG seed")
+    args = parser.parse_args()
+
+    mx.random.seed(args.seed)
+
+    dtype = getattr(mx, args.dtype)
+    model, tokenizer = T5.from_pretrained(args.model, dtype)
+
+    if args.encode_only:
+        print("[INFO] Encoding with T5...", flush=True)
+        print(args.prompt, flush=True)
+        encoder_output = model.encode(tokenizer.encode(args.prompt))
+        print(encoder_output, flush=True)
+        exit(0)
+
+    print("[INFO] Generating with T5...", flush=True)
+    print("Input: ", args.prompt, flush=True)
+
+    start = perf_counter_ns()
+    for token, n_tokens in zip(
+        generate(args.prompt, model, tokenizer, args.temp), range(args.max_tokens)
+    ):
+        if token.item() == tokenizer.eos_id:
+            break
+        print(
+            tokenizer.decode([token.item()], with_sep=n_tokens > 0),
+            end="",
+            flush=True,
+        )
+
+    n_tokens += 1
+    end = perf_counter_ns()
+    elapsed = (end - start) / 1.0e9
+    print()
+    print(f"Time: {elapsed:.2f} seconds, tokens/s: {n_tokens / elapsed:.2f}")

--- a/npcpy/gen/mlx_musicgen/utils.py
+++ b/npcpy/gen/mlx_musicgen/utils.py
@@ -1,0 +1,52 @@
+# Copyright © 2024 Apple Inc.
+
+import mlx.core as mx
+import numpy as np
+
+
+def save_audio(file: str, audio: mx.array, sampling_rate: int):
+    """
+    Save audio to a wave (.wav) file.
+    """
+    from scipy.io.wavfile import write
+
+    audio = (audio * 32767).astype(mx.int16)
+    write(file, sampling_rate, np.array(audio))
+
+
+def load_audio(file: str, sampling_rate: int, channels: int):
+    """
+    Read audio into an mx.array, resampling if necessary.
+
+    Args:
+        file (str): The audio file to open.
+        sampling_rate (int): The sample rate to resample the audio at if needed.
+        channels (int): The number of audio channels.
+
+    Returns:
+        An mx.array containing the audio waveform in float32.
+    """
+    from subprocess import CalledProcessError, run
+
+    # This launches a subprocess to decode audio while down-mixing
+    # and resampling as necessary.  Requires the ffmpeg CLI in PATH.
+    # fmt: off
+    cmd = [
+        "ffmpeg",
+        "-nostdin",
+        "-threads", "0",
+        "-i", file,
+        "-f", "s16le",
+        "-ac", str(channels),
+        "-acodec", "pcm_s16le",
+        "-ar", str(sampling_rate),
+        "-"
+    ]
+    # fmt: on
+    try:
+        out = run(cmd, capture_output=True, check=True).stdout
+    except CalledProcessError as e:
+        raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+
+    out = mx.array(np.frombuffer(out, np.int16))
+    return out.reshape(-1, channels).astype(mx.float32) / 32767.0

--- a/npcpy/mcp_server.py
+++ b/npcpy/mcp_server.py
@@ -63,16 +63,28 @@ class NPCServerState:
             db_conn=self.command_history.engine,
         )
 
-        # Resolve active NPC: explicit arg > state file > forenpc > first
-        if npc_name and npc_name in self.team.npcs:
-            self.active_npc = self.team.npcs[npc_name]
-        else:
-            if self.team.forenpc:
-                self.active_npc = self.team.forenpc
-            elif self.team.npcs:
-                self.active_npc = next(iter(self.team.npcs.values()))
+        # Resolve active NPC: explicit arg > forenpc > first NPC.
+        # If caller asked for a specific NPC that's NOT in this team, fail loudly
+        # — silent fallback to forenpc is what makes the incognide MCP picker look
+        # empty when a user picks an NPC whose team doesn't match the selected server.
+        if npc_name:
+            if npc_name in self.team.npcs:
+                self.active_npc = self.team.npcs[npc_name]
             else:
-                self.active_npc = None
+                available = list(self.team.npcs.keys())
+                print(
+                    f"[npc-mcp] ERROR: NPC '{npc_name}' is not in team at '{team_path}'. "
+                    f"Available NPCs: {available}. Pick an MCP server whose team includes this NPC, "
+                    f"or omit --npc to use the team's forenpc.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+        elif self.team.forenpc:
+            self.active_npc = self.team.forenpc
+        elif self.team.npcs:
+            self.active_npc = next(iter(self.team.npcs.values()))
+        else:
+            self.active_npc = None
 
         # Track which jinx tool names are currently registered
         self._registered_jinx_names = set()

--- a/npcpy/npc_compiler.py
+++ b/npcpy/npc_compiler.py
@@ -1526,7 +1526,15 @@ class NPC:
                         matched_names = [jinx_spec] if jinx_spec in self.team.jinxes_dict else []
 
                     if not matched_names:
-                        raise FileNotFoundError(f"NPC '{self.name}' references jinx '{jinx_spec}' but no matching jinx was found. Available jinxes: {list(self.team.jinxes_dict.keys())[:20]}...")
+                        # Warn-and-skip instead of crashing the whole process. A missing
+                        # external/foreign jinx (offline, wrong repo, rename) shouldn't
+                        # take the MCP server down with it — the NPC just has fewer tools.
+                        print(
+                            f"Warning: NPC '{self.name}' references jinx '{jinx_spec}' but no matching jinx was found. "
+                            f"Skipping. Available jinxes (first 20): {list(self.team.jinxes_dict.keys())[:20]}",
+                            file=sys.stderr,
+                        )
+                        continue
 
                     for jinx_name in matched_names:
                         if jinx_name in self.team.jinxes_dict:
@@ -2567,9 +2575,17 @@ Requirements:
 
     def to_dict(self):
         """Convert NPC to dictionary representation"""
-        jinx_rep = [] 
+        jinx_rep = []
         if self.jinxes_dict:
             jinx_rep = [ jinx.to_dict() for jinx in self.jinxes_dict.values()]
+        source_path = getattr(self, 'npc_path', None) or getattr(self, 'source_path', None) or ''
+        source_ext = ''
+        if source_path:
+            lower = source_path.lower()
+            if lower.endswith('.npc'):
+                source_ext = '.npc'
+            elif lower.endswith('.md'):
+                source_ext = '.md'
         return {
             "name": self.name,
             "primary_directive": self.primary_directive,
@@ -2578,7 +2594,9 @@ Requirements:
             "api_url": self.api_url,
             "api_key": self.api_key,
             "jinxes": self.jinxes_spec,
-            "use_global_jinxes": self.use_global_jinxes
+            "use_global_jinxes": self.use_global_jinxes,
+            "source_path": source_path,
+            "source_ext": source_ext,
         }
         
     def save(self, directory=None):
@@ -2817,6 +2835,7 @@ class Team:
         self.forenpc: Optional['NPC'] = None
         self.forenpc_name: Optional[str] = None
         self.skills_directory: Optional[str] = None
+        self.external_jinx_teams: List[str] = []
 
         if team_path:
             self.name = os.path.basename(os.path.abspath(team_path))
@@ -2889,6 +2908,21 @@ class Team:
             for jinx_obj in load_jinxes_from_directory(jinxes_dir):
                 self._raw_jinxes_list.append(jinx_obj)
 
+        # Merge jinxes from external teams listed in team.ctx (external_jinx_teams).
+        # Own-team jinxes take precedence — external ones only fill in gaps by name.
+        if getattr(self, 'external_jinx_teams', None):
+            existing_names = {j.jinx_name for j in self._raw_jinxes_list}
+            for ext_team_root in self.external_jinx_teams:
+                ext_jinxes_dir = os.path.join(ext_team_root, "jinxes")
+                if not os.path.isdir(ext_jinxes_dir):
+                    print(f"[TEAM] external_jinx_teams: skipping missing {ext_jinxes_dir}", file=sys.stderr)
+                    continue
+                for jinx_obj in load_jinxes_from_directory(ext_jinxes_dir):
+                    if jinx_obj.jinx_name in existing_names:
+                        continue
+                    self._raw_jinxes_list.append(jinx_obj)
+                    existing_names.add(jinx_obj.jinx_name)
+
         if hasattr(self, 'skills_directory') and self.skills_directory:
             skills_path = os.path.expanduser(self.skills_directory)
             if not os.path.isabs(skills_path):
@@ -2926,14 +2960,110 @@ class Team:
 
         # --- Unified Jinja template functions (dbt-style) ---
 
-        def _Jinx(name):
-            """Resolve a jinx by name to its relative path.
-            Usage: {{ Jinx('edit_file') }} → 'lib/core/files/edit_file'
+        def _Jinx(name, path=None, *, repo=None, ref=None):
+            """Resolve a jinx by name, optionally from a foreign team.
+
+            Usage:
+              {{ Jinx('edit_file') }}                                 — own team (or already-loaded external)
+              {{ Jinx('kg_search_keyword', '/abs/team/root') }}       — positional path to foreign team
+              {{ Jinx('kg_search_keyword', path='/abs/team/root') }}  — same, keyword
+              {{ Jinx('kg_search_keyword', repo='npc-worldwide/npcsh') }}
+                  — foreign team in a GitHub repo; cached to
+                    ~/.npcsh/jinx_cache/<owner>_<repo>[@<ref>]/ on first use
+              {{ Jinx('x', repo='owner/repo', ref='v1.2.0') }}        — pin a branch/tag
+
+            Foreign jinxes are loaded into this team's pool on first resolve,
+            so subsequent renders hit the normal in-memory path.
             """
-            if name in self._jinx_path_map:
+            # Already known (own-team or previously-hydrated external).
+            if name in self._jinx_path_map and not (repo or path):
                 return self._jinx_path_map[name]
-            print(f"Warning: Jinx('{name}') not found. Available: {list(self._jinx_path_map.keys())[:15]}...")
+
+            # External source requested — resolve to a team root, then load.
+            if repo or path:
+                try:
+                    team_root = _resolve_external_team_root(repo=repo, path=path, ref=ref)
+                except Exception as _e:
+                    print(f"Warning: Jinx('{name}', repo={repo!r}, path={path!r}) failed: {_e}", file=sys.stderr)
+                    return name
+
+                if team_root:
+                    _hydrate_jinx_from_team(team_root, name)
+
+                if name in self._jinx_path_map:
+                    return self._jinx_path_map[name]
+
+            # Warnings MUST go to stderr — npc_compiler runs inside the MCP server
+            # process, which uses stdout for JSON-RPC. A stray print on stdout
+            # corrupts the protocol and kills the connection.
+            print(f"Warning: Jinx('{name}') not found. Available: {list(self._jinx_path_map.keys())[:15]}...", file=sys.stderr)
             return name
+
+        def _resolve_external_team_root(repo=None, path=None, ref=None):
+            """Return a local filesystem path to a team root (directory containing
+            a jinxes/ folder), fetching from GitHub if needed. Caches under
+            ~/.npcsh/jinx_cache/. Looks recursively for a directory named
+            npc_team inside the cloned repo."""
+            if path:
+                expanded = os.path.expanduser(path)
+                return expanded if os.path.isdir(expanded) else None
+
+            if not repo:
+                return None
+
+            cache_root = os.path.expanduser('~/.npcsh/jinx_cache')
+            os.makedirs(cache_root, exist_ok=True)
+            slug = repo.replace('/', '_')
+            if ref:
+                slug = f"{slug}@{ref}"
+            clone_dir = os.path.join(cache_root, slug)
+
+            if not os.path.isdir(clone_dir):
+                import subprocess as _sp
+                url = f"https://github.com/{repo}.git"
+                cmd = ['git', 'clone', '--depth', '1']
+                if ref:
+                    cmd += ['--branch', ref]
+                cmd += [url, clone_dir]
+                _sp.run(cmd, check=True, capture_output=True)
+
+            # Find a directory named npc_team (the first one wins).
+            for root, dirs, _ in os.walk(clone_dir):
+                # Skip .git and node_modules to keep this fast.
+                dirs[:] = [d for d in dirs if d not in ('.git', 'node_modules', '.venv', 'venv', 'dist')]
+                if os.path.basename(root) == 'npc_team':
+                    return root
+            # Fallback: repo root itself if it has jinxes/ at top level.
+            if os.path.isdir(os.path.join(clone_dir, 'jinxes')):
+                return clone_dir
+            return None
+
+        def _hydrate_jinx_from_team(team_root, jinx_name):
+            """Load a single named jinx from a foreign team root into this team's
+            pool, mutating _raw_jinxes_list and _jinx_path_map in place."""
+            jinxes_dir = os.path.join(team_root, 'jinxes')
+            if not os.path.isdir(jinxes_dir):
+                return
+            # Walk to find <jinx_name>.jinx at any depth.
+            for root, _, files in os.walk(jinxes_dir):
+                target = f"{jinx_name}.jinx"
+                if target in files:
+                    jinx_path = os.path.join(root, target)
+                    try:
+                        jinx_obj = Jinx(jinx_path=jinx_path)
+                    except Exception as _e:
+                        print(f"Warning: failed to load foreign jinx {jinx_path}: {_e}", file=sys.stderr)
+                        return
+                    # De-dupe by name — own team already wins above.
+                    for existing in self._raw_jinxes_list:
+                        if existing.jinx_name == jinx_obj.jinx_name:
+                            return
+                    self._raw_jinxes_list.append(jinx_obj)
+                    rel = os.path.relpath(jinx_path, jinxes_dir)
+                    if rel.endswith('.jinx'):
+                        rel = rel[:-5]
+                    self._jinx_path_map[jinx_obj.jinx_name] = rel
+                    return
 
         def _NPC(name):
             """Reference an NPC by name.
@@ -3035,6 +3165,14 @@ class Team:
                     self.databases = ctx_data.get('databases', [])
                     self.forenpc_name = ctx_data.get('forenpc', self.forenpc_name)
                     self.skills_directory = ctx_data.get('SKILLS_DIRECTORY', None)
+                    # external_jinx_teams: list of other team root dirs whose jinxes/
+                    # directory should also be loaded into this team. Enables jinx
+                    # reuse across teams (e.g. an app-specific team pulling in the
+                    # global npcsh lib/) without copying files.
+                    _ext = ctx_data.get('external_jinx_teams') or ctx_data.get('EXTERNAL_JINX_TEAMS') or []
+                    if isinstance(_ext, str):
+                        _ext = [_ext]
+                    self.external_jinx_teams = [os.path.expanduser(str(p)) for p in _ext if p]
                 return ctx_data
         return {}
 
@@ -3326,7 +3464,7 @@ class Team:
                     except Exception:
                         directive = content
 
-            self._register_md_agent(name, directive, model=model, provider=provider, jinxes_spec=jinxes_spec)
+            self._register_md_agent(name, directive, model=model, provider=provider, jinxes_spec=jinxes_spec, source_path=fpath)
 
     def _register_or_prompt_agent(self, name: str, directive: str, source_path: str):
         """Register a markdown-declared agent, skipping names that collide with an
@@ -3337,9 +3475,9 @@ class Team:
         """
         if not name or name in self.npcs:
             return
-        self._register_md_agent(name, directive)
+        self._register_md_agent(name, directive, source_path=source_path)
 
-    def _register_md_agent(self, name: str, directive: str, model=None, provider=None, jinxes_spec=None):
+    def _register_md_agent(self, name: str, directive: str, model=None, provider=None, jinxes_spec=None, source_path: str = None):
         """Create an NPC from a markdown agent definition and add to team.
 
         Markdown agents don't have a strict .npc jinxes: spec. Resolution order:
@@ -3365,6 +3503,8 @@ class Team:
             db_conn=self.db_conn,
         )
         npc.team = self
+        if source_path:
+            npc.source_path = source_path
         self.npcs[name] = npc
         # Markdown agents never get initialize_jinxes called via the .npc load path,
         # so call it here so their jinxes_dict is actually populated.

--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -672,13 +672,22 @@ def load_npc_by_name_and_source(name, source, db_conn=None, current_path=None):
         if not npc_directory or not os.path.exists(npc_directory):
             continue
         npc_path = os.path.join(npc_directory, f"{name}.npc")
-        if os.path.exists(npc_path):
-            try:
-                npc = NPC(file=npc_path, db_conn=db_conn)
-                return npc
-            except Exception as e:
-                print(f"Error loading NPC {name} from {npc_path}: {str(e)}")
+        if not os.path.exists(npc_path):
+            # Also check agents/ subdirectory and markdown-declared agents
+            if not any(os.path.exists(os.path.join(npc_directory, p)) for p in (
+                'agents.md', 'AGENTS.md', 'CLAUDE.md', 'agents'
+            )):
                 continue
+        try:
+            # Route NPC loading through a Team so the _npc_jinja_context is
+            # built and Jinja templates in .npc files render before YAML parse.
+            team = Team(team_path=npc_directory, db_conn=db_conn)
+            npc = team.npcs.get(name)
+            if npc is not None:
+                return npc
+        except Exception as e:
+            print(f"Error loading team from {npc_directory} while resolving NPC {name}: {str(e)}")
+            continue
 
     print(f"NPC file not found: {name}.npc in {directories}")
     return None
@@ -3368,11 +3377,15 @@ def save_npc():
         npc_data = data.get("npc")
         is_global = data.get("isGlobal")
         current_path = data.get("currentPath")
+        team = data.get("team")  # 'npcsh' | 'incognide' | 'project'
 
         if not npc_data or "name" not in npc_data:
             return jsonify({"error": "Invalid NPC data"}), 400
 
-        if is_global:
+        # Prefer explicit team, fall back to isGlobal
+        if team == "incognide":
+            npc_directory = os.path.expanduser("~/.npcsh/incognide/npc_team")
+        elif team == "npcsh" or (team is None and is_global):
             npc_directory = os.path.expanduser("~/.npcsh/npc_team")
         else:
             npc_directory = os.path.join(current_path, "npc_team")
@@ -3384,6 +3397,7 @@ def save_npc():
             provider=npc_data.get("provider", ""),
             api_url=npc_data.get("api_url", ""),
             use_global_jinxes=npc_data.get("use_global_jinxes", True),
+            jinxes=npc_data.get("jinxes"),
         )
         npc.save(npc_directory)
 
@@ -3662,11 +3676,11 @@ def get_npc_team_global():
     seen_names = set()
 
     team_dirs = [
-        os.path.expanduser("~/.npcsh/npc_team"),
-        os.path.expanduser("~/.npcsh/incognide/npc_team"),
+        ("npcsh", os.path.expanduser("~/.npcsh/npc_team")),
+        ("incognide", os.path.expanduser("~/.npcsh/incognide/npc_team")),
     ]
 
-    for team_dir in team_dirs:
+    for team_name, team_dir in team_dirs:
         if not os.path.exists(team_dir):
             continue
         try:
@@ -3674,7 +3688,9 @@ def get_npc_team_global():
             for name, npc in team.npcs.items():
                 if name not in seen_names:
                     seen_names.add(name)
-                    npc_data.append(npc.to_dict())
+                    d = npc.to_dict()
+                    d["team"] = team_name
+                    npc_data.append(d)
         except Exception as e:
             print(f"Error loading team from {team_dir}: {e}")
 
@@ -3697,7 +3713,11 @@ def get_npc_team_project():
 
     try:
         team = Team(team_path=project_npc_directory, db_conn=get_db_connection())
-        npc_data = [npc.to_dict() for npc in team.npcs.values()]
+        npc_data = []
+        for npc in team.npcs.values():
+            d = npc.to_dict()
+            d["team"] = "project"
+            npc_data.append(d)
     except Exception as e:
         print(f"Error loading project team from {project_npc_directory}: {e}")
         npc_data = []
@@ -4566,64 +4586,66 @@ def inpaint_openai(image, mask, prompt, model):
     from openai import OpenAI
     from PIL import Image
     import base64
-    
+
     client = OpenAI()
-    
+
     original_size = image.size
-    
+
     if model == 'dall-e-2':
-        valid_sizes = ['256x256', '512x512', '1024x1024']
         max_dim = max(image.width, image.height)
-        
         if max_dim <= 256:
-            target_size = (256, 256)
-            size_str = '256x256'
+            target_size = (256, 256); size_str = '256x256'
         elif max_dim <= 512:
-            target_size = (512, 512)
-            size_str = '512x512'
+            target_size = (512, 512); size_str = '512x512'
         else:
-            target_size = (1024, 1024)
-            size_str = '1024x1024'
+            target_size = (1024, 1024); size_str = '1024x1024'
     else:
         valid_sizes = {
             (1024, 1024): "1024x1024",
-            (1024, 1536): "1024x1536", 
-            (1536, 1024): "1536x1024"
+            (1024, 1536): "1024x1536",
+            (1536, 1024): "1536x1024",
         }
-        
         target_size = (1024, 1024)
         for size in valid_sizes.keys():
             if image.width > image.height and size == (1536, 1024):
-                target_size = size
-                break
+                target_size = size; break
             elif image.height > image.width and size == (1024, 1536):
-                target_size = size
-                break
-        
+                target_size = size; break
         size_str = valid_sizes[target_size]
-    
+
     resized_image = image.resize(target_size, Image.Resampling.LANCZOS)
-    resized_mask = mask.resize(target_size, Image.Resampling.LANCZOS)
-    
+    # Our incoming mask is a classic "white = edit here" L-mode PNG.
+    # OpenAI's images.edit expects an RGBA PNG whose TRANSPARENT pixels are
+    # the edit region — opaque pixels are preserved. Convert accordingly.
+    mask_l = mask.convert('L').resize(target_size, Image.Resampling.NEAREST)
+    edit_rgba = Image.new('RGBA', target_size, (255, 255, 255, 255))
+    # Where mask is white (edit), set alpha=0 so OpenAI edits there.
+    alpha = mask_l.point(lambda v: 0 if v > 128 else 255)
+    edit_rgba.putalpha(alpha)
+
+    # Image sent to OpenAI should be RGBA too (transparent hole over edit area).
+    rgba_image = resized_image.convert('RGBA')
+    rgba_image.putalpha(alpha)
+
     img_bytes = io.BytesIO()
-    resized_image.save(img_bytes, format='PNG')
+    rgba_image.save(img_bytes, format='PNG')
     img_bytes.seek(0)
     img_bytes.name = 'image.png'
-    
+
     mask_bytes = io.BytesIO()
-    resized_mask.save(mask_bytes, format='PNG')
+    edit_rgba.save(mask_bytes, format='PNG')
     mask_bytes.seek(0)
     mask_bytes.name = 'mask.png'
-    
+
     response = client.images.edit(
         model=model,
         image=img_bytes,
         mask=mask_bytes,
         prompt=prompt,
         n=1,
-        size=size_str
+        size=size_str,
     )
-    
+
     if response.data[0].url:
         import requests
         img_data = requests.get(response.data[0].url).content
@@ -4631,9 +4653,17 @@ def inpaint_openai(image, mask, prompt, model):
         img_data = base64.b64decode(response.data[0].b64_json)
     else:
         raise Exception("No image data in response")
-    
+
     result_image = Image.open(io.BytesIO(img_data))
-    return result_image.resize(original_size, Image.Resampling.LANCZOS)
+    result_image = result_image.resize(original_size, Image.Resampling.LANCZOS)
+
+    # Hard-enforce "only masked pixels change" locally, matching the Gemini
+    # path, since providers occasionally regenerate more than requested.
+    full_mask_l = mask.convert('L').resize(original_size, Image.Resampling.NEAREST)
+    base = image.convert('RGBA')
+    over = result_image.convert('RGBA')
+    composed = Image.composite(over, base, full_mask_l)
+    return composed.convert(image.mode if image.mode in ('RGB', 'RGBA') else 'RGB')
 
 def inpaint_diffusers(image, mask, prompt, model):
     from diffusers import StableDiffusionInpaintPipeline
@@ -4656,48 +4686,68 @@ def inpaint_gemini(image, mask, prompt, model):
     from npcpy.gen.image_gen import generate_image
     import io
     import numpy as np
-    
-    mask_np = np.array(mask.convert('L'))
+    from PIL import Image as PILImage
+
+    # Gemini image models don't honor masks; they re-imagine the whole frame.
+    # We prompt-engineer a region hint and then enforce the mask locally by
+    # compositing the Gemini output ONLY into the masked pixels — so the
+    # unmasked area is byte-identical to the input.
+    mask_l = mask.convert('L').resize(image.size, PILImage.NEAREST)
+    mask_np = np.array(mask_l)
     ys, xs = np.where(mask_np > 128)
-    
     if len(xs) == 0:
         return image
-    
+
     x_center = int(np.mean(xs))
     y_center = int(np.mean(ys))
     width_pct = (xs.max() - xs.min()) / image.width * 100
     height_pct = (ys.max() - ys.min()) / image.height * 100
-    
+
     position = "center"
     if y_center < image.height / 3:
         position = "top"
     elif y_center > 2 * image.height / 3:
         position = "bottom"
-    
     if x_center < image.width / 3:
         position += " left"
     elif x_center > 2 * image.width / 3:
         position += " right"
-    
+
     img_bytes = io.BytesIO()
     image.save(img_bytes, format='PNG')
     img_bytes.seek(0)
-    
-    full_prompt =  f"""Using the provided image, change only the region in the {position} 
-        approximately {int(width_pct)}% wide by {int(height_pct)}% tall) to: {prompt}. 
-        
-        Keep everything else exactly the same, matching the original lighting and style.
-        You are in-painting the image. You should not be changing anything other than what was requested in prompt: {prompt}
-        """    
+
+    full_prompt = (
+        f"Using the provided image, change only the region in the {position} "
+        f"(approximately {int(width_pct)}% wide by {int(height_pct)}% tall) to: {prompt}.\n\n"
+        "Keep everything else exactly the same, matching the original lighting and style. "
+        "You are in-painting the image. Do NOT alter anything outside that region. "
+        "Return an image with the same dimensions as the input."
+    )
+
     results = generate_image(
         prompt=full_prompt,
         model=model,
         provider='gemini',
         attachments=[img_bytes],
-        n_images=1
+        n_images=1,
     )
-    
-    return results[0] if results else None
+    if not results:
+        return None
+
+    gen = results[0]
+    # Resize the generation to match the original exactly.
+    if gen.size != image.size:
+        gen = gen.resize(image.size, PILImage.LANCZOS)
+
+    # Composite: unmasked pixels come from the original, masked pixels from
+    # the generation. This hard-enforces the "only masked area changed"
+    # contract regardless of how much Gemini re-imagined.
+    base = image.convert('RGBA')
+    over = gen.convert('RGBA')
+    alpha = mask_l  # L-mode mask: white = replace, black = keep
+    composed = PILImage.composite(over, base, alpha)
+    return composed.convert(image.mode if image.mode in ('RGB', 'RGBA') else 'RGB')
 
 @app.route('/api/generate_images', methods=['POST'])
 def generate_images():

--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -4847,7 +4847,42 @@ def generate_images():
                 img_str = base64.b64encode(img_data).decode("utf-8")
                 generated_images_base64.append(f"data:image/png;base64,{img_str}")
             else:
-                print(f"Warning: gen_image returned non-PIL object ({type(pil_image)}). Skipping image conversion.")
+                # Newer OpenAI SDKs (and possibly others) return wrapper objects
+                # with `.b64_json` or `.url` instead of a raw PIL.Image. Unwrap
+                # them to a PIL.Image so the rest of the save path works.
+                converted = None
+                try:
+                    b64 = getattr(pil_image, "b64_json", None)
+                    url = getattr(pil_image, "url", None)
+                    if b64:
+                        converted = Image.open(BytesIO(base64.b64decode(b64)))
+                    elif url:
+                        import requests as _req
+                        resp = _req.get(url, timeout=30)
+                        resp.raise_for_status()
+                        converted = Image.open(BytesIO(resp.content))
+                except Exception as _e:
+                    print(f"Warning: failed to unwrap image object ({type(pil_image)}): {_e}")
+
+                if converted is not None:
+                    filename = f"{base_filename_with_time}_{i+1:03d}.png" if n > 1 else f"{base_filename_with_time}.png"
+                    filepath = os.path.join(save_dir, filename)
+                    converted.save(filepath, format="PNG")
+                    generated_filenames.append(filepath)
+                    buffered = BytesIO()
+                    converted.save(buffered, format="PNG")
+                    img_data = buffered.getvalue()
+                    generated_attachments.append({
+                        "name": filename,
+                        "type": "images",
+                        "data": img_data,
+                        "size": len(img_data),
+                    })
+                    img_str = base64.b64encode(img_data).decode("utf-8")
+                    generated_images_base64.append(f"data:image/png;base64,{img_str}")
+                    print(f"saved file to {filepath} (unwrapped from {type(pil_image).__name__})")
+                else:
+                    print(f"Warning: gen_image returned non-PIL object ({type(pil_image)}). Skipping image conversion.")
 
         
         generation_id = generate_message_id()
@@ -7363,6 +7398,60 @@ def download_hf_file():
     except Exception as e:
         print(f"Error downloading HF file: {e}")
         return jsonify({'error': str(e)}), 500
+
+@app.route('/api/generate_music', methods=['POST'])
+def generate_music_endpoint():
+    """Generate music from a text prompt.
+
+    JSON body: { prompt, provider, model?, duration?, api_key?, currentPath? }
+    Providers: 'local' (MusicGen via transformers), 'replicate' (musicgen/stable-audio/riffusion),
+    'elevenlabs' (sound-generation, <=22s).
+    """
+    try:
+        import base64 as _b64
+        from npcpy.gen.audio_gen import generate_music
+
+        data = request.json or {}
+        prompt = data.get('prompt', '').strip()
+        if not prompt:
+            return jsonify({'success': False, 'error': 'prompt is required'}), 400
+
+        provider = data.get('provider', 'replicate')
+        model = data.get('model')
+        duration = int(data.get('duration', 10))
+        api_key = data.get('api_key')
+        current_path = data.get('currentPath') or data.get('current_path') or os.path.expanduser('~/.npcsh/audio')
+
+        result = generate_music(
+            prompt=prompt,
+            provider=provider,
+            model=model,
+            duration=duration,
+            api_key=api_key,
+        )
+
+        save_dir = os.path.abspath(os.path.expanduser(current_path))
+        os.makedirs(save_dir, exist_ok=True)
+        ts = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+        filename = f'scherzo_gen_{ts}.{result["format"]}'
+        filepath = os.path.join(save_dir, filename)
+        with open(filepath, 'wb') as f:
+            f.write(result['audio'])
+
+        return jsonify({
+            'success': True,
+            'filename': filepath,
+            'format': result['format'],
+            'provider': result['provider'],
+            'model': result['model'],
+            'audio': _b64.b64encode(result['audio']).decode('utf-8'),
+        })
+
+    except Exception as e:
+        print(f"Music generation error: {e}")
+        traceback.print_exc()
+        return jsonify({'success': False, 'error': str(e)}), 500
+
 
 @app.route('/api/audio/tts', methods=['POST'])
 def text_to_speech_endpoint():

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ base_requirements = [
     "markdown",
     "networkx", 
     "PyYAML",
-    "PyMuPDF",
+    "pypdf",
     "pyautogui",
     "pydantic", 
     "pygments>=2.20.0",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ extra_files = package_files("npcpy/npc_team/")
 
 setup(
     name="npcpy",
-    version="1.4.20",
+    version="1.4.21",
     packages=find_packages(exclude=["tests*"]),
     install_requires=base_requirements,  
     extras_require={


### PR DESCRIPTION
## Summary
- **MLX-native MusicGen** on Apple Silicon (vendored from `mlx-examples/musicgen`)
- **Unified `generate_music()`** dispatcher: `local` (auto-picks MLX or PyTorch), `replicate`, `elevenlabs` with automatic fallback when a provider has no creds or fails
- **`/api/generate_music`** endpoint
- **OpenAI image fix**: duck-type `.b64_json`/`.url` instead of whitelisting specific model names — fixes `gpt-image-1.5` and any future model
- **serve.py**: unwrap non-PIL OpenAI image wrappers before saving
- **serve + npc_compiler**: team-routed NPC lookup so `{{ Jinx('...') }}` renders; `source_path`/`source_ext` on NPC dicts; `save_npc` accepts explicit team
- **Generative fill**: local PIL mask composite for OpenAI and Gemini (mask is now actually honored)