### PR TITLE
feat: add x-exa-integration header to search_exa

### DIFF
--- a/npcpy/data/web.py
+++ b/npcpy/data/web.py
@@ -30,6 +30,7 @@ def search_exa(query:str,
     if api_key is None:
         api_key = os.environ.get('EXA_API_KEY')
     exa = Exa(api_key)
+    exa.headers["x-exa-integration"] = "npcpy"
 
     results = exa.search_and_contents(
         query,


### PR DESCRIPTION
## Summary

- Adds `exa.headers[\"x-exa-integration\"] = \"npcpy\"` after client instantiation in `search_exa`, so Exa can attribute API requests originating from npcpy (and downstream consumers like npcsh) to this integration.
- One-line change; no behavior change for callers.

## Usage

No API change. Existing callers continue to work:

\`\`\`python
from npcpy.data.web import search_web
results = search_web(\"latest AI research\", provider=\"exa\", num_results=5)
\`\`\`

## Files changed

- `npcpy/data/web.py` — set `x-exa-integration` header on the `Exa` client in `search_exa`.

## Test plan

- [x] Verified on `exa-py` that `Exa(...).headers` is a mutable dict, so setting the header is safe and backward-compatible.
- [x] No public signature changes; existing `search_exa` / `search_web` callers are unaffected.