### PR TITLE
Add GRPO and PPO RL training methods

### DIFF
--- a/npcpy/ft/rl.py
+++ b/npcpy/ft/rl.py
@@ -795,7 +795,7 @@ def train_with_grpo(
     )
     optimizer = mlx_opt.AdamW(learning_rate=config.learning_rate)
 
-    print(f"GRPO: {mlx_name}, {len(groups)} groups, {len(processed)} examples, {total_iters} iters, max_len=1024")
+    print(f"GRPO: {mlx_name}, {len(groups)} groups, {len(processed)} examples, {total_iters} iters, max_len={training_args.max_seq_length}")
 
     mlx_train(
         model=model,
@@ -926,7 +926,7 @@ def train_with_ppo(
     )
     optimizer = mlx_opt.AdamW(learning_rate=config.learning_rate)
 
-    print(f"PPO: {mlx_name}, {len(records)} traces, {total_iters} iters, beta={config.beta}, clip={config.clip_eps}, max_len=1024")
+    print(f"PPO: {mlx_name}, {len(records)} traces, {total_iters} iters, beta={config.beta}, clip={config.clip_eps}, max_len={training_args.max_seq_length}")
 
     mlx_train(
         model=policy_model,

--- a/npcpy/ft/rl.py
+++ b/npcpy/ft/rl.py
@@ -41,6 +41,7 @@ except (ImportError, RuntimeError):
 
 try:
     import mlx.core as mx
+    import mlx.nn as nn
     import mlx.optimizers as mlx_opt
     from mlx_lm import load as mlx_load
     from mlx_lm.tuner.trainer import TrainingArgs as MLXTrainingArgs, train as mlx_train
@@ -48,7 +49,9 @@ try:
     MLX_AVAILABLE = True
 except ImportError:
     MLX_AVAILABLE = False
+    nn = None
 
+import numpy as np
 import random
 from typing import List, Dict, Any, Optional, Callable
 from npcpy.npc_compiler import NPC
@@ -80,6 +83,8 @@ class RLConfig:
         default_factory=lambda: ["q_proj", "k_proj", "v_proj", "o_proj"]
     )
     max_pairs: int = 200
+    group_size: int = 4
+    clip_eps: float = 0.2
     warmup_steps: int = 5
     logging_steps: int = 5
     save_steps: int = 20
@@ -581,3 +586,358 @@ def load_rl_model(
             model = model.merge_and_unload()
 
     return model, tokenizer
+
+
+def _load_mlx_model_with_lora(config: RLConfig):
+    """Load base MLX model, optionally resume from adapter, inject LoRA."""
+    mlx_name = _resolve_mlx_model(config.base_model_name)
+    if config.adapter_path and os.path.exists(os.path.join(config.adapter_path, "adapters.safetensors")):
+        model, tokenizer = mlx_load(mlx_name, adapter_path=config.adapter_path)
+    else:
+        model, tokenizer = mlx_load(mlx_name)
+    lora_cfg = {
+        "rank": config.lora_r,
+        "alpha": config.lora_alpha,
+        "dropout": config.lora_dropout,
+        "scale": config.lora_alpha / config.lora_r,
+    }
+    linear_to_lora_layers(model, _num_lora_layers(config.lora_r), lora_cfg)
+    return model, tokenizer, mlx_name
+
+
+def _save_adapter_config(path: str, mlx_name: str, config: RLConfig):
+    os.makedirs(path, exist_ok=True)
+    adapter_config = {
+        "model": mlx_name,
+        "fine_tune_type": "lora",
+        "num_layers": _num_lora_layers(config.lora_r),
+        "lora_parameters": {
+            "rank": config.lora_r,
+            "alpha": config.lora_alpha,
+            "dropout": config.lora_dropout,
+            "scale": config.lora_alpha / config.lora_r,
+        },
+    }
+    with open(os.path.join(path, "adapter_config.json"), "w") as f:
+        json.dump(adapter_config, f, indent=2)
+
+
+def _tokenize_for_ppo(tokenizer, prompt, response, max_len=2048):
+    text = f"<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n{response}"
+    tokens = tokenizer.encode(text)
+    if tokens[-1] != tokenizer.eos_token_id:
+        tokens.append(tokenizer.eos_token_id)
+    return tokens[:max_len]
+
+
+def _compute_log_probs(model, batch, lengths):
+    inputs = batch[:, :-1]
+    targets = batch[:, 1:]
+    logits = model(inputs)
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    batch_size, seq_len = targets.shape
+    flat_targets = targets.reshape(-1)
+    flat_log_probs = log_probs.reshape(-1, log_probs.shape[-1])
+    token_log_probs = flat_log_probs[mx.arange(flat_targets.size), flat_targets]
+    token_log_probs = token_log_probs.reshape(batch_size, seq_len)
+    steps = mx.arange(1, seq_len + 1)
+    mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
+    token_log_probs = token_log_probs * mask
+    per_example = token_log_probs.sum(axis=1)
+    return per_example
+
+
+def _batch_compute_log_probs(model, tokenizer, records, batch_size=16, max_len=1024):
+    """Compute reference log-probs for all records in batches."""
+    tokenized = []
+    for rec in records:
+        tokens = _tokenize_for_ppo(tokenizer, rec["instruction"], rec["response"], max_len=max_len)
+        tokenized.append(tokens)
+
+    # Sort by length for efficient batching
+    indexed = sorted(enumerate(tokenized), key=lambda x: len(x[1]))
+    ref_log_probs = [0.0] * len(records)
+
+    for i in range(0, len(indexed), batch_size):
+        batch = indexed[i:i + batch_size]
+        lengths = [len(t) for _, t in batch]
+        max_l = min(max(lengths), max_len)
+        pad_to = 32
+        padded_len = 1 + pad_to * ((max_l + pad_to - 1) // pad_to)
+        padded_len = min(padded_len, max_len)
+
+        batch_arr = np.zeros((len(batch), padded_len), np.int32)
+        batch_lengths = []
+        for j, (orig_idx, tokens) in enumerate(batch):
+            trunc = min(len(tokens), max_len)
+            batch_arr[j, :trunc] = tokens[:trunc]
+            batch_lengths.append((0, trunc))
+
+        batch_mx = mx.array(batch_arr)
+        lengths_mx = mx.array(batch_lengths)
+        lps = _compute_log_probs(model, batch_mx, lengths_mx)
+        mx.eval(lps)
+        lps_list = [float(x) for x in lps.tolist()]
+        for j, (orig_idx, _) in enumerate(batch):
+            ref_log_probs[orig_idx] = lps_list[j]
+
+    return ref_log_probs
+
+
+def train_with_grpo(
+    groups: List[Dict[str, Any]],
+    config: Optional[RLConfig] = None
+) -> str:
+    """Train with GRPO on MLX.
+
+    groups = [{"prompt": str, "responses": [(response_str, reward), ...]}, ...]
+    """
+    if config is None:
+        config = RLConfig()
+    if not MLX_AVAILABLE:
+        raise ImportError("MLX backend requires mlx and mlx-lm")
+
+    model, tokenizer, mlx_name = _load_mlx_model_with_lora(config)
+    os.makedirs(config.adapter_path, exist_ok=True)
+
+    processed = []
+    for group in groups:
+        prompt = group["prompt"]
+        responses = group["responses"]
+        if len(responses) < 2:
+            continue
+        rewards = [r for _, r in responses]
+        mean_r = sum(rewards) / len(rewards)
+        std_r = (sum((r - mean_r) ** 2 for r in rewards) / len(rewards)) ** 0.5 + 1e-6
+        for response, reward in responses:
+            advantage = (reward - mean_r) / std_r
+            text = f"<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n{response}"
+            tokens = tokenizer.encode(text)
+            if tokens[-1] != tokenizer.eos_token_id:
+                tokens.append(tokenizer.eos_token_id)
+            processed.append((tokens, 0, float(advantage)))
+
+    if len(processed) < 10:
+        print("Not enough GRPO data.")
+        return None
+
+    class _GRPOBatch:
+        def __init__(self, data):
+            self._data = data
+        def __getitem__(self, idx):
+            return self._data[idx]
+        def __len__(self):
+            return len(self._data)
+
+    dataset = _GRPOBatch(processed)
+    iters_per_epoch = max(1, len(processed) // config.group_size)
+    total_iters = iters_per_epoch * config.num_train_epochs
+    adapter_file = os.path.join(config.adapter_path, "adapters.safetensors")
+
+    def grpo_loss(model, batch, lengths, advantages):
+        inputs = batch[:, :-1]
+        targets = batch[:, 1:]
+        logits = model(inputs)
+        log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        batch_size, seq_len = targets.shape
+        flat_targets = targets.reshape(-1)
+        flat_log_probs = log_probs.reshape(-1, log_probs.shape[-1])
+        token_log_probs = flat_log_probs[mx.arange(flat_targets.size), flat_targets]
+        token_log_probs = token_log_probs.reshape(batch_size, seq_len)
+        steps = mx.arange(1, seq_len + 1)
+        mask = mx.logical_and(steps >= lengths[:, 0:1], steps <= lengths[:, 1:])
+        # Expand advantages to per-token weights
+        adv_per_token = advantages[:, mx.newaxis] * mask
+        weighted_ce = -token_log_probs * adv_per_token
+        loss = weighted_ce.sum() / (mask.sum() + 1e-8)
+        return loss, mask.sum()
+
+    def iterate_grpo_batches(dataset, batch_size, max_seq_length, loop=False, seed=None, train=False, comm_group=None):
+        idx = sorted(range(len(dataset)), key=lambda i: len(dataset[i][0]))
+        if len(dataset) < batch_size:
+            raise ValueError(f"Need >= {batch_size} examples, got {len(dataset)}")
+        batch_idx = [
+            idx[i:i + batch_size]
+            for i in range(0, len(idx) - batch_size + 1, batch_size)
+        ]
+        if seed:
+            np.random.seed(seed)
+        while True:
+            indices = np.random.permutation(len(batch_idx))
+            for i in indices:
+                batch_data = [dataset[j] for j in batch_idx[i]]
+                tokens_list, offsets, advantages = zip(*batch_data)
+                lengths = [len(t) for t in tokens_list]
+                max_len = min(max(lengths), max_seq_length)
+                pad_to = 32
+                max_length_in_batch = 1 + pad_to * ((max_len + pad_to - 1) // pad_to)
+                max_length_in_batch = min(max_length_in_batch, max_seq_length)
+                batch_arr = np.zeros((batch_size, max_length_in_batch), np.int32)
+                for j in range(batch_size):
+                    trunc = min(lengths[j], max_seq_length)
+                    batch_arr[j, :trunc] = tokens_list[j][:trunc]
+                    lengths[j] = trunc
+                yield mx.array(batch_arr), mx.array(list(zip(offsets, lengths))), mx.array(advantages)
+            if not loop:
+                break
+
+    training_args = MLXTrainingArgs(
+        batch_size=config.group_size,
+        iters=total_iters,
+        val_batches=0,
+        steps_per_report=max(1, total_iters // 20),
+        steps_per_eval=0,
+        steps_per_save=max(1, total_iters // 5),
+        max_seq_length=min(config.max_length, 1024),
+        adapter_file=adapter_file,
+        grad_checkpoint=True,
+        grad_accumulation_steps=config.gradient_accumulation_steps,
+    )
+    optimizer = mlx_opt.AdamW(learning_rate=config.learning_rate)
+
+    print(f"GRPO: {mlx_name}, {len(groups)} groups, {len(processed)} examples, {total_iters} iters, max_len=1024")
+
+    mlx_train(
+        model=model,
+        optimizer=optimizer,
+        train_dataset=dataset,
+        val_dataset=None,
+        args=training_args,
+        loss=grpo_loss,
+        iterate_batches=iterate_grpo_batches,
+    )
+
+    _save_adapter_config(config.adapter_path, mlx_name, config)
+    print(f"GRPO adapter saved to {config.adapter_path}")
+    return config.adapter_path
+
+
+def train_with_ppo(
+    records: List[Dict[str, Any]],
+    config: Optional[RLConfig] = None
+) -> str:
+    """Train with PPO on MLX.
+
+    records = [{"instruction": str, "response": str, "reward": float}, ...]
+    """
+    if config is None:
+        config = RLConfig()
+    if not MLX_AVAILABLE:
+        raise ImportError("MLX backend requires mlx and mlx-lm")
+
+    os.makedirs(config.adapter_path, exist_ok=True)
+    mlx_name = _resolve_mlx_model(config.base_model_name)
+
+    # Compute reference log-probs with a fresh model, then free it
+    print("Computing reference log-probs...")
+    ref_model, tokenizer = mlx_load(mlx_name)
+    ref_log_probs_list = _batch_compute_log_probs(ref_model, tokenizer, records, batch_size=1, max_len=1024)
+    del ref_model
+    mx.clear_cache()
+    print(f"Reference log-probs computed for {len(records)} traces")
+
+    # Load policy model with LoRA after ref model is freed
+    policy_model, tokenizer = mlx_load(mlx_name)
+    linear_to_lora_layers(
+        policy_model,
+        _num_lora_layers(config.lora_r),
+        {"rank": config.lora_r, "alpha": config.lora_alpha, "dropout": config.lora_dropout, "scale": config.lora_alpha / config.lora_r},
+    )
+
+    rewards = [r["reward"] for r in records]
+    baseline = sum(rewards) / len(rewards)
+
+    processed = []
+    for rec, ref_lp in zip(records, ref_log_probs_list):
+        tokens = _tokenize_for_ppo(tokenizer, rec["instruction"], rec["response"])
+        advantage = rec["reward"] - baseline
+        processed.append((tokens, 0, float(advantage), float(ref_lp)))
+
+    class _PPOBatch:
+        def __init__(self, data):
+            self._data = data
+        def __getitem__(self, idx):
+            return self._data[idx]
+        def __len__(self):
+            return len(self._data)
+
+    dataset = _PPOBatch(processed)
+
+    def ppo_loss(model, batch, lengths, advantages, ref_log_probs):
+        policy_log_probs = _compute_log_probs(model, batch, lengths)
+        ratio = mx.exp(policy_log_probs - ref_log_probs)
+        clipped_ratio = mx.clip(ratio, 1 - config.clip_eps, 1 + config.clip_eps)
+        surrogate1 = ratio * advantages
+        surrogate2 = clipped_ratio * advantages
+        policy_loss = -mx.minimum(surrogate1, surrogate2).mean()
+        kl = (policy_log_probs - ref_log_probs).mean()
+        loss = policy_loss + config.beta * kl
+        return loss, mx.array(len(processed))
+
+    def iterate_ppo_batches(dataset, batch_size, max_seq_length, loop=False, seed=None, train=False, comm_group=None):
+        idx = sorted(range(len(dataset)), key=lambda i: len(dataset[i][0]))
+        if len(dataset) < batch_size:
+            raise ValueError(f"Need >= {batch_size} examples, got {len(dataset)}")
+        batch_idx = [
+            idx[i:i + batch_size]
+            for i in range(0, len(idx) - batch_size + 1, batch_size)
+        ]
+        if seed:
+            np.random.seed(seed)
+        while True:
+            indices = np.random.permutation(len(batch_idx))
+            for i in indices:
+                batch_data = [dataset[j] for j in batch_idx[i]]
+                tokens_list, offsets, advantages, ref_lps = zip(*batch_data)
+                lengths = [len(t) for t in tokens_list]
+                max_len = min(max(lengths), max_seq_length)
+                pad_to = 32
+                max_length_in_batch = 1 + pad_to * ((max_len + pad_to - 1) // pad_to)
+                max_length_in_batch = min(max_length_in_batch, max_seq_length)
+                batch_arr = np.zeros((batch_size, max_length_in_batch), np.int32)
+                for j in range(batch_size):
+                    trunc = min(lengths[j], max_seq_length)
+                    batch_arr[j, :trunc] = tokens_list[j][:trunc]
+                    lengths[j] = trunc
+                yield (
+                    mx.array(batch_arr),
+                    mx.array(list(zip(offsets, lengths))),
+                    mx.array(advantages),
+                    mx.array(ref_lps),
+                )
+            if not loop:
+                break
+
+    iters_per_epoch = max(1, len(processed) // config.group_size)
+    total_iters = iters_per_epoch * config.num_train_epochs
+    adapter_file = os.path.join(config.adapter_path, "adapters.safetensors")
+
+    training_args = MLXTrainingArgs(
+        batch_size=config.group_size,
+        iters=total_iters,
+        val_batches=0,
+        steps_per_report=max(1, total_iters // 20),
+        steps_per_eval=0,
+        steps_per_save=max(1, total_iters // 5),
+        max_seq_length=min(config.max_length, 1024),
+        adapter_file=adapter_file,
+        grad_checkpoint=True,
+        grad_accumulation_steps=config.gradient_accumulation_steps,
+    )
+    optimizer = mlx_opt.AdamW(learning_rate=config.learning_rate)
+
+    print(f"PPO: {mlx_name}, {len(records)} traces, {total_iters} iters, beta={config.beta}, clip={config.clip_eps}, max_len=1024")
+
+    mlx_train(
+        model=policy_model,
+        optimizer=optimizer,
+        train_dataset=dataset,
+        val_dataset=None,
+        args=training_args,
+        loss=ppo_loss,
+        iterate_batches=iterate_ppo_batches,
+    )
+
+    _save_adapter_config(config.adapter_path, mlx_name, config)
+    print(f"PPO adapter saved to {config.adapter_path}")
+    return config.adapter_path


### PR DESCRIPTION
## Summary
Adds GRPO and PPO reinforcement learning training methods to npcpy.ft.rl.

- train_with_grpo(): Group Relative Policy Optimization with advantage-weighted loss on MLX
- train_with_ppo(): Proximal Policy Optimization with reference log-probs, clipped ratio, and KL penalty on MLX
- Helper functions for batched reference probability computation
- Numerically stable log-softmax using logsumexp for MLX compatibility