### PR TITLE
Chat mode plain text, tool_capable system prompt passthrough, disable thinking fixes

### DIFF
--- a/npcpy/npc_compiler.py
+++ b/npcpy/npc_compiler.py
@@ -1879,12 +1879,12 @@ class NPC:
 
         return tools_for_llm, tool_executors
 
-    def get_system_prompt(self, simple=False):
+    def get_system_prompt(self, simple=False, tool_capable=False):
         """Get system prompt for the NPC"""
         if simple or self.plain_system_message:
             return self.primary_directive
         else:
-            return get_system_message(self, team=self.team)
+            return get_system_message(self, team=self.team, tool_capable=tool_capable)
 
     def _setup_db(self):
         """Set up database tables and determine type"""

--- a/npcpy/npc_sysenv.py
+++ b/npcpy/npc_sysenv.py
@@ -1214,7 +1214,7 @@ The current date and time are : {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
                 if you are in the [ReAct loop] and you are asked to use jinxes, refer to these guidelines:
               [BEGIN GUIDELINES FOR JINX EXECUTION]
                   Use jinxes when appropriate. For example:
-                    
+
                     - If you are asked about something up-to-date or dynamic (e.g., latest exchange rates)
                     - If the user asks you to read or edit a file
                     - If the user asks for code that should be executed
@@ -1222,14 +1222,14 @@ The current date and time are : {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
                     - If they request a screenshot, audio, or image manipulation
                     - Situations requiring file parsing (e.g., CSV or JSON loading)
                     - Scripted workflows or pipelines, e.g., generate a chart, fetch data, summarize from source, etc.
-                    
+
                     You MUST use a jinx if the request directly refers to a tool the AI cannot handle directly (e.g., 'run', 'open', 'search', etc).
-                    
+
                     You do not need to use a jinx if:
 
                     - the user asks a simple question like 'what is 2+2' or 'who invented linux', essentially any question which only requires general knowledge.
                     - The user asks you to write them a story (unless they separately specify saving it to a file, then you should directly write the story to be output through a jinx to said file.)
-                    To invoke a jinx, return the action 'invoke_jinx' along with the jinx specific name. 
+                    To invoke a jinx, return the action 'invoke_jinx' along with the jinx specific name.
                     An example for a jinx-specific return would be:
                     """ +"""
                     {
@@ -1237,18 +1237,18 @@ The current date and time are : {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
                         "jinx_name": "file_reader",
                         "explanation": "Read the contents of <full_filename_path_from_user_request> and <detailed explanation of how to accomplish the problem outlined in the request>."
                     }
-                    
-                    
+
+
                     Do not use the jinx names as the action keys. You must use the action 'invoke_jinx' to invoke a jinx!
                     Do not invent jinx names. Use only those provided.
-                  
-                
+
+
                 Respond with a single JSON object only.
                 To use a jinx, set action to jinx, jinx_name to one of [{jinx_names_str}], and inputs with the required parameters.
 
               [END GUIDELINES FOR JINX EXECUTION]
-                                            
-              
+
+
 """
                 system_message += jinx_instructions
 

--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -5651,9 +5651,13 @@ def stream():
     # clean_messages_for_llm imported from npcpy.streaming
     messages = clean_messages_for_llm(messages)
 
-    # ensure_system_prompt imported from npcpy.streaming
-    messages = ensure_system_prompt(messages, npc=npc_object)
     exe_mode = data.get('executionMode','chat')
+    # Chat mode should never see jinx instructions; strip them from the NPC
+    # before building the system prompt so the model outputs plain text.
+    if exe_mode == 'chat' and npc_object is not None and hasattr(npc_object, 'jinxes_dict'):
+        npc_object.jinxes_dict = {}
+    # ensure_system_prompt imported from npcpy.streaming
+    messages = ensure_system_prompt(messages, npc=npc_object, tool_capable=(exe_mode == 'tool_agent'))
 
     stream_response = {"output": "", "messages": messages}
 
@@ -5684,8 +5688,15 @@ def stream():
     if exe_mode == 'chat':
         print(f"[DEBUG] Calling get_llm_response with images={images}, attachments={attachment_paths_for_llm}")
         thinking_kwargs = {}
-        if not disable_thinking:
-            thinking_kwargs['thinking'] = True
+        if disable_thinking:
+            if provider in ('ollama',):
+                thinking_kwargs['think'] = False
+            else:
+                thinking_kwargs['reasoning_effort'] = 'none'
+        elif provider in ('anthropic',):
+            thinking_kwargs['thinking'] = {"type": "enabled", "budget_tokens": 10000}
+            if params and 'temperature' in params:
+                del params['temperature']
         stream_response = get_llm_response(
             commandstr,
             messages=messages,
@@ -5791,7 +5802,7 @@ def stream():
         if not messages:
             messages = []
         if not any(m.get('role') == 'system' for m in messages):
-            system_prompt = npc_object.get_system_prompt() if npc_object else "You are a helpful assistant with access to tools."
+            system_prompt = npc_object.get_system_prompt(tool_capable=True) if npc_object else "You are a helpful assistant with access to tools."
             messages.insert(0, {'role': 'system', 'content': system_prompt})
 
         def stream_mcp_sse():

--- a/npcpy/streaming.py
+++ b/npcpy/streaming.py
@@ -125,7 +125,7 @@ def clean_messages_for_llm(messages: List[dict]) -> List[dict]:
 # System prompt management
 # ---------------------------------------------------------------------------
 
-def ensure_system_prompt(messages: List[dict], npc=None, system_prompt: str = None) -> List[dict]:
+def ensure_system_prompt(messages: List[dict], npc=None, system_prompt: str = None, tool_capable=False) -> List[dict]:
     """Ensure messages start with a system prompt.
 
     If *system_prompt* is given it takes precedence; otherwise falls back to
@@ -133,7 +133,7 @@ def ensure_system_prompt(messages: List[dict], npc=None, system_prompt: str = No
     """
     prompt = system_prompt
     if prompt is None and npc is not None and hasattr(npc, 'get_system_prompt'):
-        prompt = npc.get_system_prompt()
+        prompt = npc.get_system_prompt(tool_capable=tool_capable)
 
     if not prompt:
         return messages

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ extra_files = package_files("npcpy/npc_team/")
 
 setup(
     name="npcpy",
-    version="1.4.29",
+    version="1.4.30",
     packages=find_packages(exclude=["tests*"]),
     install_requires=base_requirements,  
     extras_require={


### PR DESCRIPTION
Changes:
- Pass tool_capable through ensure_system_prompt -> get_system_prompt -> get_system_message so chat mode gets plain text instead of JSON action output
- Strip jinx instructions from NPC in chat mode by emptying jinxes_dict before system prompt generation
- Handle disable_thinking for Ollama (think=False) and Anthropic (reasoning_effort=none / thinking enabled)
- Version bump to 1.4.30