### PR TITLE
docs: fix non-existent load_jinx_from_file in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,9 +707,9 @@ for npc, result in zip(npcs, results.data):
 You can also pass a list directly to `jinx.execute()`:
 
 ```python
-from npcpy.npc_compiler import load_jinx_from_file
+from npcpy.npc_compiler import Jinx
 
-jinx = load_jinx_from_file('npc_team/jinxes/analyze.jinx')
+jinx = Jinx(jinx_path='npc_team/jinxes/analyze.jinx')
 results = jinx.execute({'topic': 'rate limiting'}, npc=npcs)  # list → parallel NPCArray run
 ```
 


### PR DESCRIPTION
While reading the README I hit a code example that does not run as written.

The "load a jinx from a file" snippet imports and calls `load_jinx_from_file` from `npcpy.npc_compiler`:

```python
from npcpy.npc_compiler import load_jinx_from_file

jinx = load_jinx_from_file('npc_team/jinxes/analyze.jinx')
```

But `load_jinx_from_file` does not exist anywhere in the package — it raises `ImportError`. Loading a jinx from a file is done through the `Jinx` class with the `jinx_path` argument:

```python
from npcpy.npc_compiler import Jinx

jinx = Jinx(jinx_path='npc_team/jinxes/analyze.jinx')
```

This is the pattern used internally throughout `npc_compiler.py` (e.g. `Jinx(jinx_path=jinx_path)` in `load_jinxes_from_directory` and elsewhere) and in `examples/example_jinx_usage.py:188`. The rest of the snippet (`jinx.execute({...}, npc=...)`) is unchanged and remains valid.

**Change:** one-line import + constructor fix in `README.md` so the documented example works.