### PR TITLE
fix(ft): chunk encode_texts forward pass by batch_size

### DIFF
--- a/npcpy/ft/embeddings.py
+++ b/npcpy/ft/embeddings.py
@@ -590,23 +590,42 @@ def encode_texts(
     tokenizer,
     device: str = "cpu",
     max_length: int = 256,
+    batch_size: int = 32,
 ) -> List[List[float]]:
+    """Encode texts to normalized embeddings, one ``batch_size`` chunk at a time.
+
+    The whole list used to be tokenized and forwarded in a single pass, so peak
+    memory scaled with ``len(texts)`` and large inputs went OOM. Chunking keeps
+    peak memory bounded by ``batch_size`` instead.
+
+    Results are unchanged by chunking: padding is per-batch, but ``_mean_pooling``
+    divides by the attention mask, so pad tokens never contribute to the mean.
+    """
     if not TORCH_AVAILABLE:
         raise ImportError("PyTorch required")
+
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
 
     model.eval()
     dev = torch.device(device)
 
-    enc = tokenizer(texts, padding=True, truncation=True,
-                    max_length=max_length, return_tensors="pt")
-    enc = {k: v.to(dev) for k, v in enc.items()}
+    embeddings: List[List[float]] = []
 
     with torch.no_grad():
-        out = model(**enc).last_hidden_state
-        pooled = _mean_pooling(out, enc["attention_mask"])
-        emb = F.normalize(projector(pooled), p=2, dim=-1)
+        for start in range(0, len(texts), batch_size):
+            batch = texts[start:start + batch_size]
+            enc = tokenizer(batch, padding=True, truncation=True,
+                            max_length=max_length, return_tensors="pt")
+            enc = {k: v.to(dev) for k, v in enc.items()}
 
-    return emb.cpu().numpy().tolist()
+            out = model(**enc).last_hidden_state
+            pooled = _mean_pooling(out, enc["attention_mask"])
+            emb = F.normalize(projector(pooled), p=2, dim=-1)
+
+            embeddings.extend(emb.cpu().numpy().tolist())
+
+    return embeddings
 
 def evaluate_embeddings(
     anchors: List[str],
@@ -617,10 +636,11 @@ def evaluate_embeddings(
     tokenizer,
     device: str = "cpu",
     max_length: int = 256,
+    batch_size: int = 32,
 ) -> Dict[str, float]:
-    a_emb = np.array(encode_texts(anchors, model, projector, tokenizer, device, max_length))
-    p_emb = np.array(encode_texts(positives, model, projector, tokenizer, device, max_length))
-    n_emb = np.array(encode_texts(negatives, model, projector, tokenizer, device, max_length))
+    a_emb = np.array(encode_texts(anchors, model, projector, tokenizer, device, max_length, batch_size))
+    p_emb = np.array(encode_texts(positives, model, projector, tokenizer, device, max_length, batch_size))
+    n_emb = np.array(encode_texts(negatives, model, projector, tokenizer, device, max_length, batch_size))
 
     combined = np.concatenate([p_emb, n_emb], axis=0)
     sim = a_emb @ combined.T

--- a/tests/test_ft_embeddings.py
+++ b/tests/test_ft_embeddings.py
@@ -323,3 +323,153 @@ class TestFoundationModelTraining:
         )
         path = run_hilbert_embedding_sft_torch(anchors, positives, config=config)
         assert path == config.output_model_path
+
+
+class TestEncodeTextsBatching:
+    """`encode_texts` must chunk its forward pass instead of doing one giant pass.
+
+    Pre-fix it tokenized and forwarded the entire `texts` list at once, so peak
+    memory scaled with `len(texts)` and large inputs went OOM. `evaluate_embeddings`
+    is an in-repo caller that hands it full datasets.
+
+    These tests use a stub tokenizer and a tiny torch module, so they need no
+    network and no HuggingFace download (unlike the `@pytest.mark.slow` suites).
+    """
+
+    HIDDEN = 8
+    VOCAB = 16
+    DIM = 4
+
+    @staticmethod
+    def _token_id(token, vocab):
+        # Deterministic across processes, unlike hash() on str.
+        return (sum(ord(c) for c in token) % (vocab - 1)) + 1
+
+    @pytest.fixture
+    def stubs(self):
+        import torch
+        from types import SimpleNamespace
+
+        vocab, hidden, dim = self.VOCAB, self.HIDDEN, self.DIM
+        token_id = self._token_id
+
+        class StubTokenizer:
+            """Pads each call to that call's own batch maximum, like a real one."""
+
+            def __init__(self):
+                self.batches = []
+
+            def __call__(self, texts, padding=True, truncation=True,
+                         max_length=256, return_tensors="pt"):
+                texts = list(texts)
+                self.batches.append(texts)
+                token_lists = [t.split()[:max_length] for t in texts]
+                width = max(len(t) for t in token_lists)
+                input_ids = torch.zeros(len(texts), width, dtype=torch.long)
+                attention_mask = torch.zeros(len(texts), width, dtype=torch.long)
+                for row, tokens in enumerate(token_lists):
+                    for col, tok in enumerate(tokens):
+                        input_ids[row, col] = token_id(tok, vocab)
+                        attention_mask[row, col] = 1
+                return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+        class StubModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(vocab, hidden)
+                self.forward_batch_sizes = []
+
+            def forward(self, input_ids=None, attention_mask=None, **kwargs):
+                self.forward_batch_sizes.append(int(input_ids.shape[0]))
+                return SimpleNamespace(last_hidden_state=self.embedding(input_ids))
+
+        torch.manual_seed(0)
+        model = StubModel()
+        projector = torch.nn.Linear(hidden, dim)
+        return model, projector, StubTokenizer()
+
+    @staticmethod
+    def _texts(n):
+        # Deliberately uneven token counts so per-batch padding differs by chunk.
+        return [" ".join(["tok%d" % (i + k) for k in range(1 + i % 3)]) for i in range(n)]
+
+    def test_chunks_the_forward_pass_by_batch_size(self, stubs):
+        from npcpy.ft.embeddings import encode_texts
+
+        model, projector, tokenizer = stubs
+        embeddings = encode_texts(self._texts(7), model, projector, tokenizer,
+                                  device="cpu", max_length=32, batch_size=3)
+
+        # 7 texts at batch_size=3 => three forward passes, never one pass of 7.
+        assert model.forward_batch_sizes == [3, 3, 1]
+        assert [len(b) for b in tokenizer.batches] == [3, 3, 1]
+        assert len(embeddings) == 7
+        assert all(len(e) == self.DIM for e in embeddings)
+
+    def test_batching_does_not_change_the_embeddings(self, stubs):
+        """Chunking must be numerically transparent.
+
+        Padding is per-batch, but `_mean_pooling` divides by the attention mask,
+        so pad positions cannot leak into the mean.
+        """
+        from npcpy.ft.embeddings import encode_texts
+
+        model, projector, tokenizer = stubs
+        texts = self._texts(6)
+
+        one_pass = encode_texts(texts, model, projector, tokenizer,
+                                device="cpu", max_length=32, batch_size=len(texts))
+        per_item = encode_texts(texts, model, projector, tokenizer,
+                                device="cpu", max_length=32, batch_size=1)
+        uneven = encode_texts(texts, model, projector, tokenizer,
+                              device="cpu", max_length=32, batch_size=4)
+
+        assert model.forward_batch_sizes == [6, 1, 1, 1, 1, 1, 1, 4, 2]
+        np.testing.assert_allclose(np.array(per_item), np.array(one_pass), atol=1e-6)
+        np.testing.assert_allclose(np.array(uneven), np.array(one_pass), atol=1e-6)
+
+    def test_default_batch_size_bounds_peak_memory(self, stubs):
+        """The default must not be unbounded: 70 texts cannot be one pass of 70."""
+        from npcpy.ft.embeddings import encode_texts
+
+        model, projector, tokenizer = stubs
+        embeddings = encode_texts(self._texts(70), model, projector, tokenizer,
+                                  device="cpu", max_length=32)
+
+        assert len(embeddings) == 70
+        assert max(model.forward_batch_sizes) <= 32
+        assert len(model.forward_batch_sizes) > 1
+
+    def test_empty_input_does_no_forward_pass(self, stubs):
+        from npcpy.ft.embeddings import encode_texts
+
+        model, projector, tokenizer = stubs
+        assert encode_texts([], model, projector, tokenizer, device="cpu") == []
+        assert model.forward_batch_sizes == []
+        assert tokenizer.batches == []
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_rejects_non_positive_batch_size(self, stubs, bad):
+        from npcpy.ft.embeddings import encode_texts
+
+        model, projector, tokenizer = stubs
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            encode_texts(self._texts(3), model, projector, tokenizer,
+                         device="cpu", batch_size=bad)
+
+    def test_evaluate_embeddings_threads_batch_size_through(self, stubs):
+        from npcpy.ft.embeddings import evaluate_embeddings
+
+        model, projector, tokenizer = stubs
+        anchors = self._texts(4)
+        positives = self._texts(4)
+        negatives = self._texts(4)
+
+        metrics = evaluate_embeddings(anchors, positives, negatives, model,
+                                      projector, tokenizer, device="cpu",
+                                      max_length=32, batch_size=2)
+
+        # Three lists of 4 at batch_size=2 => 6 forward passes of 2, none of 4.
+        assert model.forward_batch_sizes == [2, 2, 2, 2, 2, 2]
+        assert set(metrics) == {"mrr", "recall@1", "recall@5"}
+        assert 0.0 <= metrics["mrr"] <= 1.0


### PR DESCRIPTION
Addresses **item 2** of #244.

`encode_texts` tokenized and forwarded the **entire** `texts` list in a single pass, so peak memory scaled with `len(texts)` rather than with any batch size. `evaluate_embeddings` is an in-repo caller that makes this easy to hit: it hands `encode_texts` the full anchor, positive and negative lists, so evaluating a large set is three unbounded forward passes.

### Change

- `encode_texts` gained a `batch_size` parameter (default `32`) and now encodes in chunks, extending the result list per chunk.
- `evaluate_embeddings` gained the same parameter and threads it through to its three `encode_texts` calls.
- `batch_size < 1` raises `ValueError` rather than silently producing an empty result (`range(0, n, 0)` would raise an opaque error).

The new parameter is appended **last** in both signatures, so the existing positional call style used inside `evaluate_embeddings` (`encode_texts(anchors, model, projector, tokenizer, device, max_length)`) and in `tests/test_ft_embeddings.py` keeps working unchanged.

**Chunking is numerically transparent.** Padding is now per-batch rather than across the whole input, but `_mean_pooling` divides by the attention mask, so pad positions never contribute to the pooled vector. There is a test asserting this explicitly (`batch_size=1`, `batch_size=4` and one single pass all produce the same embeddings to `atol=1e-6`).

### Scope

#244 lists five items; this PR deliberately does only item 2, the one that is a straightforward bug. Not touched here:

- **item 1 (`trust_remote_code`)** — real, but it is a new feature rather than a broken path: the field does not exist on `EmbeddingConfig` at all, and would need forwarding to `AutoModel.from_pretrained`, `AutoTokenizer.from_pretrained` and `load_embedding_model`.
- **item 3 (`device` default)** — a `_default_device()` helper changes the default behaviour of every config, so it seemed worth keeping separate.
- **item 4 (`run_embedding_sft_mlx`)** — the issue itself offers "either remove it or port it to `mlx_lm`", which is a maintainer decision, and I have no Apple silicon to verify a port on.
- **item 5 (triplet JSONL loader)** — a new feature.

Happy to follow up on any of these if you'd like them, in whatever order suits you.

### Tests

Added `TestEncodeTextsBatching` (7 tests) to `tests/test_ft_embeddings.py`: chunk boundaries and call counts, numerical equivalence across batch sizes, a bounded default, empty input doing zero forward passes, `ValueError` on non-positive batch sizes, and `evaluate_embeddings` threading the value through.

These use a stub tokenizer plus a tiny `torch.nn.Embedding` model, so unlike the existing `@pytest.mark.slow` classes they need **no network and no HuggingFace download**. Token ids are derived from `sum(ord(c))` rather than `hash()` so they are stable across processes.

### Verification

Windows 11, Python 3.13, `torch 2.13.0+cpu`, in a throwaway venv with `pip install -e .`

```
# new tests
$ pytest tests/test_ft_embeddings.py -k Batching -q
7 passed, 18 deselected

# negative control: revert ONLY the embeddings.py hunk, keep the tests
$ git checkout HEAD -- npcpy/ft/embeddings.py && pytest tests/test_ft_embeddings.py -k Batching -q
7 failed, 18 deselected

# whole file, fast tests
pristine main : 10 passed, 8 deselected
this branch   : 17 passed, 8 deselected     (10 pre-existing + 7 new)

# pre-existing integration tests that actually call the changed functions
# (real sentence-transformers/all-MiniLM-L6-v2 download)
$ pytest tests/test_ft_embeddings.py::TestClassicalEmbeddingTraining -q
pristine main : 4 passed
this branch   : 4 passed
```

Lint, using the exact invocation from `.github/workflows/ci.yml`:

```
$ ruff check npcpy/ft/embeddings.py tests/test_ft_embeddings.py --select=E,F,W --ignore=E501,E402,F401
All checks passed!        # identical on pristine main
```

### Limitations, stated honestly

- `tests/test_ft_embeddings.py` is **not currently run by CI** (`ci.yml` enumerates test files individually and this one is not among them, presumably because it needs `torch`). So these tests will not gate anything until that file is added to a workflow — happy to add it if you want, though it would mean putting `torch` in the CI install.
- I verified on **CPU only**. The chunking is device-agnostic, but I have no CUDA or MPS hardware to confirm the memory win on an accelerator.
- The MLX paths were not exercised at all.
