### PR TITLE
Support Streamable HTTP MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,22 @@ if __name__ == "__main__":
 
 The team's NPCs automatically get access to MCP tools alongside their jinxes.
 
+For a remote server that uses Streamable HTTP, set its transport explicitly.
+For example, Parallel Search MCP provides live web search and URL fetching
+without requiring an account or API key:
+
+```yaml
+forenpc: assistant
+mcp_servers:
+  - url: https://search.parallel.ai/mcp
+    transport: streamable-http
+    tools:
+      - web_search
+      - web_fetch
+```
+
+Remote URLs continue to use SSE when `transport` is omitted.
+
 </details>
 
 <details>

--- a/npcpy/serve.py
+++ b/npcpy/serve.py
@@ -201,7 +201,8 @@ class MCPClientNPC:
           - str: command string starting with python/npx/uvx/node/docker
           - dict with 'path': local script file
           - dict with 'command' + 'args': arbitrary stdio command (npx, docker, uvx, node, etc.)
-          - dict with 'url': SSE/HTTP remote server
+          - dict with 'url': remote server (SSE by default)
+          - dict with 'url' + transport='streamable-http': Streamable HTTP server
         """
         if isinstance(server_spec, str):
             if _is_command_string(server_spec):
@@ -222,12 +223,31 @@ class MCPClientNPC:
             self.session = None
         self._exit_stack = AsyncExitStack()
         if "url" in server_spec:
-            from mcp.client.sse import sse_client
             url = server_spec["url"]
-            self._log(f"Connecting to SSE server: {url}")
             self.server_script_path = url
-            sse_transport = await self._exit_stack.enter_async_context(sse_client(url))
-            self.session = await self._exit_stack.enter_async_context(ClientSession(*sse_transport))
+            transport = server_spec.get("transport", "sse")
+            if not isinstance(transport, str):
+                raise ValueError("MCP remote transport must be 'sse' or 'streamable-http'")
+            transport = transport.strip().lower()
+
+            if transport == "sse":
+                from mcp.client.sse import sse_client
+                self._log(f"Connecting to SSE server: {url}")
+                sse_transport = await self._exit_stack.enter_async_context(sse_client(url))
+                self.session = await self._exit_stack.enter_async_context(ClientSession(*sse_transport))
+            elif transport == "streamable-http":
+                from mcp.client.streamable_http import streamablehttp_client
+                self._log(f"Connecting to Streamable HTTP server: {url}")
+                http_transport = await self._exit_stack.enter_async_context(streamablehttp_client(url))
+                read_stream, write_stream, *_ = http_transport
+                self.session = await self._exit_stack.enter_async_context(
+                    ClientSession(read_stream, write_stream)
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported MCP remote transport '{transport}'; "
+                    "expected 'sse' or 'streamable-http'"
+                )
         elif "command" in server_spec:
             command = server_spec["command"]
             args = server_spec.get("args", [])
@@ -305,7 +325,7 @@ class MCPClientNPC:
         tool_names = list(self.tool_map.keys())
         self._log(f"Connection successful. Tools: {', '.join(tool_names) if tool_names else 'None'}")
     def connect_sync(self, server_spec) -> bool:
-        """Connect synchronously. server_spec: str (path) or dict with path/command/url."""
+        """Connect synchronously using a path, command, SSE URL, or Streamable HTTP URL."""
         self._cleanup_sync()
         loop = self._get_loop()
         try:

--- a/tests/test_mcp_and_skills.py
+++ b/tests/test_mcp_and_skills.py
@@ -1,8 +1,12 @@
 """Tests for MCP server integration and skills functionality."""
 
+import asyncio
 import os
 import tempfile
 import shutil
+import sys
+import types
+from contextlib import asynccontextmanager
 import pytest
 from pathlib import Path
 
@@ -120,6 +124,111 @@ jinxes:
 
 class TestMCPClientNPC:
     """Test MCPClientNPC class."""
+
+    @pytest.fixture
+    def remote_mcp_fakes(self, monkeypatch):
+        """Replace MCP transports and sessions with hermetic async fakes."""
+        from npcpy import serve
+
+        calls = {"sse": [], "streamable-http": [], "session_args": []}
+
+        @asynccontextmanager
+        async def sse_client(url):
+            calls["sse"].append(url)
+            yield ("sse-read", "sse-write")
+
+        @asynccontextmanager
+        async def streamablehttp_client(url):
+            calls["streamable-http"].append(url)
+            yield ("http-read", "http-write", lambda: "session-id")
+
+        class FakeClientSession:
+            def __init__(self, *args):
+                calls["session_args"].append(args)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+            async def initialize(self):
+                return None
+
+            async def list_tools(self):
+                return types.SimpleNamespace(tools=[])
+
+        sse_module = types.ModuleType("mcp.client.sse")
+        sse_module.sse_client = sse_client
+        streamable_module = types.ModuleType("mcp.client.streamable_http")
+        streamable_module.streamablehttp_client = streamablehttp_client
+        monkeypatch.setitem(sys.modules, "mcp.client.sse", sse_module)
+        monkeypatch.setitem(sys.modules, "mcp.client.streamable_http", streamable_module)
+        monkeypatch.setattr(serve, "ClientSession", FakeClientSession)
+        return calls
+
+    @staticmethod
+    async def _connect_and_close(client, server_spec):
+        try:
+            await client._connect_async(server_spec)
+        finally:
+            if client._exit_stack is not None:
+                await client._exit_stack.aclose()
+
+    def test_remote_url_preserves_sse_default(self, remote_mcp_fakes):
+        """A URL without an explicit transport remains an SSE connection."""
+        from npcpy.serve import MCPClientNPC
+
+        client = MCPClientNPC(debug=False)
+        asyncio.run(self._connect_and_close(client, {"url": "https://example.com/sse"}))
+
+        assert remote_mcp_fakes["sse"] == ["https://example.com/sse"]
+        assert remote_mcp_fakes["streamable-http"] == []
+        assert remote_mcp_fakes["session_args"] == [("sse-read", "sse-write")]
+
+    def test_remote_url_supports_streamable_http(self, remote_mcp_fakes):
+        """Streamable HTTP uses only the transport's read and write streams."""
+        from npcpy.serve import MCPClientNPC
+
+        client = MCPClientNPC(debug=False)
+        asyncio.run(self._connect_and_close(client, {
+            "url": "https://search.parallel.ai/mcp",
+            "transport": "streamable-http",
+        }))
+
+        assert remote_mcp_fakes["sse"] == []
+        assert remote_mcp_fakes["streamable-http"] == ["https://search.parallel.ai/mcp"]
+        assert remote_mcp_fakes["session_args"] == [("http-read", "http-write")]
+
+    def test_remote_url_rejects_unknown_transport(self, remote_mcp_fakes):
+        """Unknown transport names fail before a remote connection is opened."""
+        from npcpy.serve import MCPClientNPC
+
+        client = MCPClientNPC(debug=False)
+        with pytest.raises(ValueError, match="expected 'sse' or 'streamable-http'"):
+            asyncio.run(self._connect_and_close(client, {
+                "url": "https://example.com/mcp",
+                "transport": "websocket",
+            }))
+
+        assert remote_mcp_fakes["sse"] == []
+        assert remote_mcp_fakes["streamable-http"] == []
+        assert remote_mcp_fakes["session_args"] == []
+
+    def test_remote_url_rejects_non_string_transport(self, remote_mcp_fakes):
+        """Transport configuration must be a documented string value."""
+        from npcpy.serve import MCPClientNPC
+
+        client = MCPClientNPC(debug=False)
+        with pytest.raises(ValueError, match="must be 'sse' or 'streamable-http'"):
+            asyncio.run(self._connect_and_close(client, {
+                "url": "https://example.com/mcp",
+                "transport": True,
+            }))
+
+        assert remote_mcp_fakes["sse"] == []
+        assert remote_mcp_fakes["streamable-http"] == []
+        assert remote_mcp_fakes["session_args"] == []
 
     def test_mcp_client_import(self):
         """Test that MCPClientNPC can be imported."""


### PR DESCRIPTION
Remote MCP URLs currently use SSE, so teams cannot configure servers that use Streamable HTTP. This adds an explicit transport choice while keeping SSE as the default for existing configurations.

## What changed

- support `transport: streamable-http` for remote MCP server entries
- keep URL entries on SSE when `transport` is omitted
- document Parallel Search MCP as an opt-in remote example
- cover both transports and invalid configuration with hermetic tests

## Validation

- 14 focused MCP tests passed; 1 existing integration test was skipped
- 25 broader tool and MCP tests passed; 1 existing integration test was skipped
- Python compilation and `git diff --check` passed

The transport path is covered with SDK fakes; live endpoint discovery was not run.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.